### PR TITLE
Feat: Advance tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 				"@emotion/react": "^11.11.3",
 				"@mantine/carousel": "^7.4.1",
 				"@mantine/core": "^7.4.1",
+				"@mantine/dates": "^7.4.1",
 				"@mantine/dropzone": "^7.4.1",
 				"@mantine/hooks": "^7.4.1",
 				"@mantine/notifications": "^7.4.1",
@@ -2145,6 +2146,29 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@mantine/dates": {
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-7.4.1.tgz",
+			"integrity": "sha512-a7DNeJmLCgnFbd9NAEQ/LP998zLFPu8IWVjtJY/YJ4OUIDLEPi56OzuopA3epVzGkMcEvL4Ak78Z23KfZPJepg==",
+			"dependencies": {
+				"clsx": "2.0.0"
+			},
+			"peerDependencies": {
+				"@mantine/core": "7.4.1",
+				"@mantine/hooks": "7.4.1",
+				"dayjs": ">=1.0.0",
+				"react": "^18.2.0",
+				"react-dom": "^18.2.0"
+			}
+		},
+		"node_modules/@mantine/dates/node_modules/clsx": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
+			"integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/@mantine/dropzone": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"@emotion/react": "^11.11.3",
 		"@mantine/carousel": "^7.4.1",
 		"@mantine/core": "^7.4.1",
+		"@mantine/dates": "^7.4.1",
 		"@mantine/dropzone": "^7.4.1",
 		"@mantine/hooks": "^7.4.1",
 		"@mantine/notifications": "^7.4.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3128,7 +3128,6 @@ dependencies = [
  "cargo-tarpaulin",
  "chrono",
  "log",
- "num-traits",
  "once_cell",
  "paste",
  "pretty_assertions",
@@ -3136,6 +3135,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "surrealdb",
  "tauri",
  "tauri-build",
@@ -5620,6 +5621,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "subtle"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,14 +30,14 @@ async-trait = "0.1.77"
 thiserror = "1.0.56"
 once_cell = "1.19.0"
 url = "2.4.1"
-num-traits = "0.2.17"
 anyhow = "1.0.79"
 base64 = "0.21.7"
 pretty_env_logger = "0.5.0"
 log = "0.4.20"
 regex = "1.10.3"
 paste = "1.0.14"
-cargo-tarpaulin = "0.27.3"
+strum_macros = "0.26.1"
+strum = "0.26.1"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/src-tauri/src/core/dbmanager/mod.rs
+++ b/src-tauri/src/core/dbmanager/mod.rs
@@ -44,7 +44,6 @@ impl DatabaseManagerStatus {
 pub struct DatabaseManager {
     cmd: Command,
     child: Option<Child>,
-    // api_process: Option<GroupChild>,
 }
 
 impl DatabaseManager {    
@@ -53,7 +52,7 @@ impl DatabaseManager {
 
         let tc = TCommand::new_sidecar("surreal")
             .map_err(|err| DBManagerError::ExcutedCommandFailed(anyhow!(err)))?
-            .args(["start", "-A", "--user", "root", "--pass", "root"]);
+            .args(["start", /* "file:mydatabase.db",*/ "-A", "--auth", "--user", "root", "--pass", "root"]);
         
         Ok(DatabaseManager {
             cmd: tc.into(),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -86,6 +86,7 @@ fn main() {
             resource::application::explore_the_file,
             resource::application::add_resource_tag,
             resource::application::remove_resource_tag,
+            resource::application::update_resource_tag,
             resource::application::get_resource_detail,
             resource::application::list_resource,
             resource::application::querying_by_string,

--- a/src-tauri/src/modules/category/application/command/import_category/mod.rs
+++ b/src-tauri/src/modules/category/application/command/import_category/mod.rs
@@ -167,7 +167,7 @@ impl<'a> ImportCategoryHandler<'a> {
                 .into_iter()
                 .map(|val| ResourceTaggingPlainObject { 
                     id: tagids.get(&val.id.to_string()).unwrap().to_owned(), 
-                    added_at: val.added_at,
+                    ..val
                 })
                 .collect::<Vec<ResourceTaggingPlainObject>>();
             let new_res = ResourceFactory::from_plain(ResourcePlainObject {

--- a/src-tauri/src/modules/common/domain/mapper.rs
+++ b/src-tauri/src/modules/common/domain/mapper.rs
@@ -3,3 +3,20 @@ pub trait DomainModelMapper<V> : Sized {
 
     fn from_domain(value: V) -> Self;
 }
+
+#[macro_export]
+macro_rules! domain_model_valueobj_mapper {
+    ($do_name: ident, $vo_name: ident) => {
+        impl DomainModelMapper<$vo_name> for $do_name {
+            fn to_domain(self) -> $vo_name {
+                let v = serde_json::to_value(self).unwrap();
+                serde_json::from_value::<$vo_name>(v).unwrap()
+            }
+        
+            fn from_domain(value: $vo_name) -> Self {
+                let v = serde_json::to_value(value).unwrap();
+                serde_json::from_value::<$do_name>(v).unwrap()
+            }
+        }
+    };
+}

--- a/src-tauri/src/modules/common/repository/predef.rs
+++ b/src-tauri/src/modules/common/repository/predef.rs
@@ -8,6 +8,80 @@ use crate::modules::common::repository::env;
 
 pub static PRE_DEFINED_REPOSITORY: PreDefinedRepository<'_> = PreDefinedRepository::init(&env::DB);
 
+pub mod sql_utils {
+    use chrono::NaiveDate;
+
+    use super::sql_predefn;
+
+    const DATE_FORAMTER: &str = "%Y-%m-%d";
+
+    pub fn sql_range_date(field_name: &str, value: (&Option<NaiveDate>, &Option<NaiveDate>)) -> String {
+        if let (Some(start), Some(end)) = value {
+            return sql_predefn::between(
+                field_name, 
+                format!("type::datetime('{}')", start.format(DATE_FORAMTER)), 
+                format!("type::datetime('{}')", end.format(DATE_FORAMTER)),
+            );
+        }
+        if let Some(start) = value.0 {
+            return format!("({} >= type::datetime('{}'))", field_name, start.format(DATE_FORAMTER))
+        }
+        if let Some(end) = value.1 {
+            return format!("({} <= type::datetime('{}'))", field_name, end.format(DATE_FORAMTER))
+        }
+        return "(true)".to_string();
+    }
+
+    pub fn sql_range_number(field_name: &str, value: (&Option<usize>, &Option<usize>)) -> String {
+        match value {
+            (Some(start), Some(end)) => {
+                sql_predefn::between(field_name, start, end)
+            },
+            (Some(start), None) => {
+                format!("({} >= {})", field_name, start)
+            },
+            (None, Some(end)) => {
+                return format!("({} <= {})", field_name, end)
+            }
+            _ => "(true)".to_string()
+        }
+    }
+
+    /// It will generated the
+    /// ```rust
+    /// assert_eq!("!(person.married == true)", sql_with_prefix("(person.married == true)"))
+    /// ```
+    pub fn sql_with_prefix<S: Into<String>>(not_flag: bool, s: S) -> String {
+        match not_flag {
+            true => format!("!{}", s.into()),
+            false => s.into(),
+        }
+    }
+
+    /// It will generated the
+    /// ```rust
+    /// assert_eq!("(person.married == true)", sql_equal("person.married", true))
+    /// ```
+    pub fn sql_equal<S: ToString>(field_name: &str, target: &S) -> String {
+        format!("({} == {})", field_name, target.to_string())
+    }
+
+    /// It will generated the
+    /// ```rust
+    /// assert_eq!("(person.emails CONTAINS .com)", sql_contain("person.emails", ".com"))
+    /// ```
+    pub fn sql_contain<S: Into<String>>(field_name: &str, target: S) -> String {
+        format!("({} CONTAINS {})", field_name, target.into())
+    }
+
+    /// It will generated the
+    /// ```rust
+    /// assert_eq!("(person.name CONTAINS \"john\")", sql_contain_string("person.name", "john"))
+    /// ```
+    pub fn sql_contain_string<S: Into<String>>(field_name: &str, target: S) -> String {
+        format!("({} CONTAINS \"{}\")", field_name, target.into())
+    }
+}
 
 pub mod sql_predefn {
     use std::fmt::Display;

--- a/src-tauri/src/modules/resource/application/command/create_resource/mod.rs
+++ b/src-tauri/src/modules/resource/application/command/create_resource/mod.rs
@@ -84,13 +84,13 @@ impl ICommandHandler<CreateResourceCommand> for CreateResourceHandler<'_> {
 
         if let Some(tags) = tags {
             for tag in tags {
-                let tag_id = self.tag_repo
-                    .is_exist(&tag)
+                let tag = self.tag_repo
+                    .find_by_id(&tag)
                     .await
-                    .then(|| TagID::from(tag))
+                    .or(Err(ResourceGenericError::DBInternalError()))?
                     .ok_or(ResourceGenericError::TagNotExists())?;
 
-                new_resource.get_mut_tagging().add_tag(&tag_id)?;
+                new_resource.get_mut_tagging().add_tag(&tag, None)?;
             }
         } 
         

--- a/src-tauri/src/modules/resource/application/command/mod.rs
+++ b/src-tauri/src/modules/resource/application/command/mod.rs
@@ -9,3 +9,6 @@ pub use resource_add_tag::*;
 
 mod resource_remove_tag;
 pub use resource_remove_tag::*;
+
+mod resource_update_tag;
+pub use resource_update_tag::*;

--- a/src-tauri/src/modules/resource/application/command/resource_add_tag/dto.rs
+++ b/src-tauri/src/modules/resource/application/command/resource_add_tag/dto.rs
@@ -1,8 +1,13 @@
 use serde::{Serialize, Deserialize};
 
+use crate::modules::resource::application::dto::ResourceTaggingAttrPayloadDto;
+
 #[derive(Serialize, Deserialize)]
 pub struct ResourceAddTagDto {
     pub id: String,
 
     pub tag_id: String,
+
+    pub attrval: Option<ResourceTaggingAttrPayloadDto>,
 }
+

--- a/src-tauri/src/modules/resource/application/command/resource_update_tag/dto.rs
+++ b/src-tauri/src/modules/resource/application/command/resource_update_tag/dto.rs
@@ -1,0 +1,12 @@
+use serde::{Serialize, Deserialize};
+
+use crate::modules::resource::application::dto::ResourceTaggingAttrPayloadDto;
+
+#[derive(Serialize, Deserialize)]
+pub struct ResourceUpdateTagDto {
+    pub id: String,
+
+    pub tag_id: String,
+
+    pub attrval: ResourceTaggingAttrPayloadDto,
+}

--- a/src-tauri/src/modules/resource/application/command/resource_update_tag/mod.rs
+++ b/src-tauri/src/modules/resource/application/command/resource_update_tag/mod.rs
@@ -1,0 +1,83 @@
+use anyhow::Error;
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::command_from_dto;
+use crate::modules::resource::application::dto::ResourceTaggingAttrPayloadDto;
+use crate::modules::resource::domain::entities::TaggingAttrPayload;
+use crate::modules::resource::domain::{ResourceGenericError, ResourceID};
+use crate::modules::resource::repository::ResourceRepository;
+use crate::modules::common::application::ICommandHandler;
+use crate::modules::tag::domain::TagID;
+use crate::modules::tag::repository::TagRepository;
+
+mod dto;
+pub use dto::*;
+
+#[derive(Deserialize)]
+pub struct ResourceUpdateTagCommand {
+    pub id: String,
+
+    pub tag_id: String,
+
+    pub attrval: ResourceTaggingAttrPayloadDto,
+}
+command_from_dto!(ResourceUpdateTagCommand, ResourceUpdateTagDto);
+
+// =====================================
+pub struct ResourceUpdateTagHandler<'a> {
+    resource_repo: &'a ResourceRepository<'a>,
+    tag_repo: &'a TagRepository<'a>,
+}
+
+impl<'a> ResourceUpdateTagHandler<'a> {
+    pub fn register(resource_repo: &'a ResourceRepository, tag_repo: &'a TagRepository) -> Self {
+        Self { resource_repo, tag_repo }
+    }
+}
+
+#[async_trait]
+impl ICommandHandler<ResourceUpdateTagCommand> for ResourceUpdateTagHandler<'_> {
+
+    fn get_name() -> String {
+        String::from("Update Resource Tag Command")
+    }
+
+    type Output = ResourceID;
+
+    async fn execute(&self, command: ResourceUpdateTagCommand) -> Result<Self::Output, Error> {
+        let ResourceUpdateTagCommand { 
+            id,
+            tag_id,
+            attrval,
+        } = command;
+
+
+        //get TagID
+        let tag = self.tag_repo
+            .find_by_id(&tag_id)
+            .await
+            .or(Err(ResourceGenericError::DBInternalError()))?
+            .ok_or(ResourceGenericError::TagNotExists())?;   
+
+        // find by id
+        let mut resource = self.resource_repo
+            .find_by_id(id)
+            .await
+            .or(Err(ResourceGenericError::DBInternalError()))?
+            .ok_or(ResourceGenericError::IdNotFound())?;
+                
+        // remove tag
+        resource.get_mut_tagging().update_tag(&tag, attrval.into())?;
+        
+        // save
+        let result = self.resource_repo
+            .save(resource)
+            .await;
+        
+        match result {
+            Ok(value) => Ok(value.take_id()),
+            _ => Err(ResourceGenericError::DBInternalError().into()),
+        }
+    }
+}

--- a/src-tauri/src/modules/resource/application/dto/request.rs
+++ b/src-tauri/src/modules/resource/application/dto/request.rs
@@ -1,16 +1,24 @@
 use serde::{Serialize, Deserialize};
 
-#[derive(Serialize, Deserialize)]
-pub struct ResourceListQueryDto {
-    pub id: Option<String>,
+use crate::modules::resource::domain::entities::TaggingAttrPayload;
 
-    pub name: Option<String>,
-
-    pub belong_category: Option<String>, 
-
-    pub order_by: Option<String>,
-
-    pub limit: Option<i64>,
-
-    pub start: Option<i64>,
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ResourceTaggingAttrPayloadDto {
+    None,
+    Number(i64),
+    Text(String),
+    Date(String),
+    Bool(bool),
+}
+impl Into<TaggingAttrPayload> for ResourceTaggingAttrPayloadDto {
+    fn into(self) -> TaggingAttrPayload {
+        match self {
+            Self::None => TaggingAttrPayload::None,
+            Self::Number(val) => TaggingAttrPayload::Number(val),
+            Self::Text(val) => TaggingAttrPayload::Text(val),
+            Self::Date(val) => TaggingAttrPayload::Date(val),
+            Self::Bool(val) => TaggingAttrPayload::Bool(val),
+        }
+    }
 }

--- a/src-tauri/src/modules/resource/application/query/bystring/semantic.rs
+++ b/src-tauri/src/modules/resource/application/query/bystring/semantic.rs
@@ -1,4 +1,5 @@
 use crate::modules::common::infrastructure::QueryBuilder;
+use crate::modules::tag::application::dto::TagAttrDto;
 use crate::modules::tag::repository::TagQueryRepository;
 use crate::modules::tag::infrastructure::TagQueryBuilder;
 use crate::modules::resource::infrastructure::{AttributeValue, AttributeValueType, SystemTag};
@@ -6,6 +7,12 @@ use crate::modules::resource::domain::ResourceGenericError;
 
 use super::token::QueryToken;
 use super::types::TokenSymbol;
+
+macro_rules! block {
+    ($xs:block) => {
+        loop { break $xs }
+    };
+}
 
 macro_rules! semantic_err {
     ($msg: expr) => {
@@ -53,25 +60,40 @@ impl<'a> StringQLSemantic<'a> {
                         _ => new_tokens.push(token.clone())
                     }
                 },
-                QueryToken::TagToken { .. } => {
-                    new_tokens.push(token.clone())
-                },
-                QueryToken::SystemTagToken { namespace, value, .. } => {
+                QueryToken::TagToken { attrtype, .. }  => block!({ // NOTE: this is early breakout the match
+                    if *attrtype == AttributeValueType::None {
+                        new_tokens.push(token.clone());
+                        break;
+                    }
+
+                    if let Some(attr) = self.peek_attribute(current + 2) {
+                        let mut new_token = token.clone();
+
+                        let new_attrval = AttributeValue::parse_from(attr, *attrtype)
+                            .map_err(|err| semantic_err!(err.to_string()))?;
+
+                        new_token.set_attribute(new_attrval);
+                        new_tokens.push(new_token);
+                        break;
+                    }
+                    // all tag's attribute are optional
+                    else {
+                        new_tokens.push(token.clone());
+                    }
+                }),
+                QueryToken::SystemTagToken { attrtype, .. } => {
                     let mut new_token = token.clone();
 
-                    if let Ok(attr_type) = SystemTag::attr_type(namespace, value) {
+                    // peek next 2 token, if it is attribute
+                    // syntax check will make this to be true
+                    if let Some(attr) = self.peek_attribute(current + 2) {
+                        let new_attrval = AttributeValue::parse_from(attr, *attrtype)
+                            .map_err(|err| semantic_err!(err.to_string()))?;
 
-                        // peek next 2 token, if it is attribute
-                        // syntax check will make this to be true
-                        if let Some(attr) = self.peek_attribute(current + 2) {
-                            let new_attrval = AttributeValue::parse_from(attr, attr_type)
-                                .map_err(|err| semantic_err!(err.to_string()))?;
-    
-                            new_token.set_attribute(new_attrval);   
-                        }
-                        else if attr_type != AttributeValueType::OptionText {
-                            return Err(semantic_err!("Attribute can't be empty"));
-                        }    
+                        new_token.set_attribute(new_attrval);   
+                    }
+                    else if *attrtype != AttributeValueType::OptionText {
+                        return Err(semantic_err!("Attribute can't be empty"));
                     }
                     
                     new_tokens.push(new_token);
@@ -87,45 +109,64 @@ impl<'a> StringQLSemantic<'a> {
         Ok(())
     }
 
-    async fn generate_tag_id(&mut self) -> Result<(), ResourceGenericError> {
+    async fn generate_tag_id_and_attr_type(&mut self) -> Result<(), ResourceGenericError> {
         for token in self.tokens.iter_mut() {
-            if let QueryToken::TagToken { namespace, value, .. } = token {
-                let mut builder = TagQueryBuilder::new()
-                    .set_name(value.to_string());
-
-                if let Some(namepace) = namespace {
-                    builder = builder.set_belong_subject_name(namepace.to_string());
-                }
-
-                if let Some(category) = self.belong_category {
-                    builder = builder.set_belong_category(category);
-                }
-
-                let builder_result = builder.build()
-                    .map_err(|err| ResourceGenericError::InvalidQueryingString { message: err.to_string() })?;
-
-                let result = &self.repo.query(builder_result)
-                    .await
-                    .or(Err(ResourceGenericError::DBInternalError()))?;
-
-                // find multiple same name tags
-                let _ = match result.len() {
-                    1 => {
-                        let result = result.first().unwrap();
-                        token.set_tag_id(result.id.to_string());
-                        Ok(())
-                    },
-                    0 => Err(ResourceGenericError::TagNotExists()),
-                    _ => Err(ResourceGenericError::FindAmbiguousTags()),
-                }?;
+            match token {
+                QueryToken::SystemTagToken { namespace, value, .. } => {
+                    if let Ok(attr_type) = SystemTag::attr_type(namespace.as_str(), value.as_str()) {
+                        token.set_attribute_type(attr_type);
+                    }
+                },
+                QueryToken::TagToken { namespace, value, .. } => {
+                    let mut builder = TagQueryBuilder::new()
+                        .set_name(value.to_string());
+    
+                    if let Some(namepace) = namespace {
+                        builder = builder.set_belong_subject_name(namepace.to_string());
+                    }
+    
+                    if let Some(category) = self.belong_category {
+                        builder = builder.set_belong_category(category);
+                    }
+    
+                    let builder_result = builder.build()
+                        .map_err(|err| ResourceGenericError::InvalidQueryingString { message: err.to_string() })?;
+    
+                    let result = &self.repo.query(builder_result)
+                        .await
+                        .or(Err(ResourceGenericError::DBInternalError()))?;
+    
+                    // find multiple same name tags
+                    let _ = match result.len() {
+                        1 => {
+                            let result = result.first().unwrap();
+                            token.set_tag_id(result.id.to_string());
+                            
+                            let attr_type = match result.attrval {
+                                TagAttrDto::Normal => AttributeValueType::None,
+                                TagAttrDto::Number { .. } => AttributeValueType::NumberRange,
+                                TagAttrDto::Text { .. } => AttributeValueType::Text,
+                                TagAttrDto::Date { .. } => AttributeValueType::DateRange,
+                                TagAttrDto::Bool { .. } => AttributeValueType::Bool,
+                            };
+                            token.set_attribute_type(attr_type);
+    
+                            Ok(())
+                        },
+                        0 => Err(ResourceGenericError::TagNotExists()),
+                        _ => Err(ResourceGenericError::FindAmbiguousTags()),
+                    }?;
+                },
+                _ => { },
             }
+
         }
 
         Ok(())
     }
 
     pub async fn parse(&mut self) -> Result<Vec<QueryToken>, ResourceGenericError> {
-        self.generate_tag_id().await?;
+        self.generate_tag_id_and_attr_type().await?;
         self.parse_value()?;
 
         Ok(self.tokens.clone())

--- a/src-tauri/src/modules/resource/application/query/bystring/sqlgen.rs
+++ b/src-tauri/src/modules/resource/application/query/bystring/sqlgen.rs
@@ -62,30 +62,32 @@ impl<'a> StringQLObjectGenerator<'a> {
                         _ => {}
                     };
                 },
-                QueryToken::TagToken { id, .. } => {
+                QueryToken::TagToken { id, attrval, .. } => {
+                    let (id, attrval) = (id.to_string(), attrval.clone());
                     match ops_stack.last().unwrap().0 {
                         TokenSymbol::Include => {
-                            self.builder.add_item(StringQLItem::new(StringQLPrefix::Include, id.to_string(), None));
+                            self.builder.add_item(StringQLItem::new(StringQLPrefix::Include, id, attrval, false));
                         },
                         TokenSymbol::Exclude => {
-                            self.builder.add_item(StringQLItem::new(StringQLPrefix::Exclude, id.to_string(), None));
+                            self.builder.add_item(StringQLItem::new(StringQLPrefix::Exclude, id, attrval, false));
                         }
                         _ => {
-                            tag_stack.push(StringQLItem::new(StringQLPrefix::Inherit, id.to_string(), None));
+                            tag_stack.push(StringQLItem::new(StringQLPrefix::Inherit, id, attrval, false));
                         },
                     }
                 },
                 QueryToken::SystemTagToken { namespace, value, attrval, .. } => {
+                    let attrval = attrval.clone();
                     let name = SystemTag::full_name(namespace, value);
                     match ops_stack.last().unwrap().0 {
                         TokenSymbol::Include => {
-                            self.builder.add_item(StringQLItem::new(StringQLPrefix::Include, name, attrval.clone()));
+                            self.builder.add_item(StringQLItem::new(StringQLPrefix::Include, name, attrval, true));
                         },
                         TokenSymbol::Exclude => {
-                            self.builder.add_item(StringQLItem::new(StringQLPrefix::Exclude, name, attrval.clone()));
+                            self.builder.add_item(StringQLItem::new(StringQLPrefix::Exclude, name, attrval, true));
                         }
                         _ => {
-                            tag_stack.push(StringQLItem::new(StringQLPrefix::Inherit, name, attrval.clone()));
+                            tag_stack.push(StringQLItem::new(StringQLPrefix::Inherit, name, attrval, true));
                         },
                     }
                 },

--- a/src-tauri/src/modules/resource/application/query/bystring/token.rs
+++ b/src-tauri/src/modules/resource/application/query/bystring/token.rs
@@ -1,4 +1,4 @@
-use crate::modules::resource::infrastructure::AttributeValue;
+use crate::modules::resource::infrastructure::{AttributeValue, AttributeValueType};
 
 use super::types::TokenSymbol;
 
@@ -13,12 +13,15 @@ pub enum QueryToken {
         id: String,
         namespace: Option<String>,
         value: String,
+        attrval: Option<AttributeValue>,
+        attrtype: AttributeValueType,
     },
     SystemTagToken{
         namespace: String,
         symbol: TokenSymbol,
         value: String,
         attrval: Option<AttributeValue>,
+        attrtype: AttributeValueType,
     },
     AttributeToken{
         symbol: TokenSymbol,
@@ -32,16 +35,11 @@ impl QueryToken {
     }
 
     pub fn new_tag(symbol: TokenSymbol, namespace: Option<String>, value: String) -> Self {
-        Self::TagToken{
-            id: String::default(),
-            symbol,
-            value,
-            namespace,
-        }
+        Self::TagToken{ id: String::default(), symbol, value, namespace, attrval: None, attrtype: AttributeValueType::None }
     }
 
     pub fn new_system_tag(symbol: TokenSymbol, namespace: String, value: String) -> Self {
-        Self::SystemTagToken { symbol, namespace, value, attrval: None }
+        Self::SystemTagToken { symbol, namespace, value, attrval: None, attrtype: AttributeValueType::None }
     }
 
     pub fn new_attribute(symbol: TokenSymbol, value: String) -> Self {
@@ -52,8 +50,18 @@ impl QueryToken {
     }
 
     pub fn set_attribute(&mut self, val: AttributeValue) {
-        if let Self::SystemTagToken { attrval, .. } = self {
-            *attrval = Some(val);
+        match self {
+            Self::SystemTagToken { attrval, .. } => *attrval = Some(val),
+            Self::TagToken { attrval, .. } => *attrval = Some(val),
+            _ => { },
+        }
+    }
+
+    pub fn set_attribute_type(&mut self, new_type: AttributeValueType) {
+        match self {
+            Self::SystemTagToken { attrtype, .. } => *attrtype = new_type,
+            Self::TagToken { attrtype, .. } => *attrtype = new_type,
+            _ => { },
         }
     }
 

--- a/src-tauri/src/modules/resource/application/query/query_resource/dto.rs
+++ b/src-tauri/src/modules/resource/application/query/query_resource/dto.rs
@@ -1,3 +1,16 @@
 use serde::{Serialize, Deserialize};
 
-// Defined common dto here...
+#[derive(Serialize, Deserialize)]
+pub struct ResourceListQueryDto {
+    pub id: Option<String>,
+
+    pub name: Option<String>,
+
+    pub belong_category: Option<String>, 
+
+    pub order_by: Option<String>,
+
+    pub limit: Option<i64>,
+
+    pub start: Option<i64>,
+}

--- a/src-tauri/src/modules/resource/application/query/query_resource/mod.rs
+++ b/src-tauri/src/modules/resource/application/query/query_resource/mod.rs
@@ -8,7 +8,10 @@ use crate::modules::common::infrastructure::QueryBuilder;
 use crate::modules::resource::domain::ResourceGenericError;
 use crate::modules::resource::infrastructure::ResourceQueryBuilder;
 use crate::modules::resource::repository::ResourceQueryRepository;
-use crate::modules::resource::application::dto::{ResourceListQueryDto, ResourceResDto};
+use crate::modules::resource::application::dto::ResourceResDto;
+
+mod dto;
+pub use dto::ResourceListQueryDto;
 
 #[derive(Deserialize)]
 pub struct ListResourceQuery { 

--- a/src-tauri/src/modules/resource/application/query/resource_detail/dto.rs
+++ b/src-tauri/src/modules/resource/application/query/resource_detail/dto.rs
@@ -2,7 +2,8 @@ use surrealdb::sql::Thing;
 use serde::{Deserialize, Serialize};
 
 use crate::modules::common::application::thing_serialize;
-use crate::modules::resource::application::dto::{ResourceFileDto, ResourceUrlDto};
+use crate::modules::resource::application::dto::{ResourceFileDto, ResourceTaggingAttrPayloadDto, ResourceUrlDto};
+use crate::modules::tag::application::dto::TagAttrResDto;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ResourceTagDto {
@@ -19,6 +20,11 @@ pub struct ResourceTagDto {
     pub subject_name: String,
 
     pub tagged_count: i64,
+
+    #[serde(flatten)]
+    pub attr: TagAttrResDto,
+
+    pub attrval: ResourceTaggingAttrPayloadDto,
 
     pub added_at: String,
 

--- a/src-tauri/src/modules/resource/application/query/resource_detail/dto.rs
+++ b/src-tauri/src/modules/resource/application/query/resource_detail/dto.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::modules::common::application::thing_serialize;
 use crate::modules::resource::application::dto::{ResourceFileDto, ResourceTaggingAttrPayloadDto, ResourceUrlDto};
-use crate::modules::tag::application::dto::TagAttrResDto;
+use crate::modules::tag::application::dto::TagAttrDto;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ResourceTagDto {
@@ -22,7 +22,7 @@ pub struct ResourceTagDto {
     pub tagged_count: i64,
 
     #[serde(flatten)]
-    pub attr: TagAttrResDto,
+    pub attr: TagAttrDto,
 
     pub attrval: ResourceTaggingAttrPayloadDto,
 

--- a/src-tauri/src/modules/resource/application/service.rs
+++ b/src-tauri/src/modules/resource/application/service.rs
@@ -90,7 +90,16 @@ impl<'a> ResourceService<'a> {
         Ok(result)
     }
 
+    pub async fn update_resource_tag(&self, data: ResourceUpdateTagDto) -> Result<ResourceID, ResourceError> {
+        let command = ResourceUpdateTagCommand::from(data);
 
+        let result = ResourceUpdateTagHandler::register(self.resource_repository, self.tag_respository)
+            .execute(command)
+            .await
+            .map_err(|err| ResourceError::UpdateTag(anyhow!(err)))?;
+
+        Ok(result)
+    }
 
     pub async fn get_resource_by_id(&self, resource_id: String) -> Result<Option<ResourceResDto>, ResourceError> {
         let query = GetByIdResourceQuery { id: resource_id };

--- a/src-tauri/src/modules/resource/application/tauri-command.rs
+++ b/src-tauri/src/modules/resource/application/tauri-command.rs
@@ -42,6 +42,14 @@ pub async fn remove_resource_tag(data: ResourceRemoveTagDto) -> Result<ResourceI
     Ok(result)
 }
 
+#[tauri::command(rename_all = "snake_case")]
+pub async fn update_resource_tag(data: ResourceUpdateTagDto) -> Result<ResourceID, ResourceError> {
+    let result = RESOURCE_SERVICE
+        .update_resource_tag(data)
+        .await?;
+
+    Ok(result)
+}
 
 #[tauri::command]
 pub async fn get_all_resource() -> Result<Vec<ResourceResDto>, ResourceError> {

--- a/src-tauri/src/modules/resource/domain/entities/restag.rs
+++ b/src-tauri/src/modules/resource/domain/entities/restag.rs
@@ -1,9 +1,20 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-use crate::modules::resource::domain::valueobj::ResourceTaggingVO;
+use crate::modules::common::infrastructure::dateutils;
+use crate::modules::resource::domain::valueobj::{ResourceTaggingAttrVO, ResourceTaggingVO};
 use crate::modules::resource::domain::ResourceGenericError;
-use crate::modules::tag::domain::TagID;
+use crate::modules::tag::domain::valueobj::TagAttrVO;
+use crate::modules::tag::domain::{Tag, TagID};
 
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TaggingAttrPayload {
+    None,
+    Number(i64),
+    Text(String),
+    Date(String),
+    Bool(bool),
+}
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct ResourceTaggingEntity {
@@ -11,21 +22,44 @@ pub struct ResourceTaggingEntity {
 
     add_tags: Vec<ResourceTaggingVO>,
 
-    del_tags: Vec<ResourceTaggingVO>,
+    update_tags: Vec<ResourceTaggingVO>,
+
+    del_tags: Vec<TagID>,
 }
 
 impl ResourceTaggingEntity {
     pub fn new(tags: Vec<ResourceTaggingVO>) -> Self {
-        Self { tags, add_tags: Vec::new(), del_tags: Vec::new() }
+        Self {
+            tags,
+            add_tags: Vec::new(), 
+            del_tags: Vec::new(), 
+            update_tags: Vec::new(),
+        }
     }
 
-    pub fn add_tag(&mut self, tag_id: &TagID) -> Result<(), ResourceGenericError> {
-        if self.tags.iter().any(|v| v.id == *tag_id) {
+    pub fn add_tag(&mut self, tag: &Tag, payload: Option<TaggingAttrPayload>) -> Result<(), ResourceGenericError> {
+        if self.tags.iter().any(|v| v.id == *tag.get_id()) {
             return Err(ResourceGenericError::AddSameTag());
         }
 
-        self.add_tags.push(ResourceTaggingVO::new(tag_id.to_string()));
+        let attrval = match payload {
+            Some(data) => Self::create_tagging_attr(tag, data),
+            None => Ok(Self::create_default_tagging_attr(tag))
+        }?;
 
+        self.add_tags.push(ResourceTaggingVO::new(tag.get_id().to_string(), attrval));
+
+        Ok(())
+    }
+
+    pub fn update_tag(&mut self, tag: &Tag, payload: TaggingAttrPayload) -> Result<(), ResourceGenericError> {
+        if self.tags.iter().any(|v| v.id == *tag.get_id()) == false {
+            return Err(ResourceGenericError::TagNotExists());
+        }
+
+        let attrval = Self::create_tagging_attr(&tag, payload)?;
+
+        self.update_tags.push(ResourceTaggingVO::new(tag.get_id().to_string(), attrval));
         Ok(())
     }
 
@@ -34,12 +68,12 @@ impl ResourceTaggingEntity {
             return Err(ResourceGenericError::TagNotExists());
         }
 
-        self.del_tags.push(ResourceTaggingVO::new(tag_id.to_string()));
+        self.del_tags.push(tag_id.clone());
         
         Ok(())
     }
 
-    pub fn get_del_tags(&self) -> &Vec<ResourceTaggingVO> {
+    pub fn get_del_tags(&self) -> &Vec<TagID> {
         &self.del_tags
     }
 
@@ -51,7 +85,56 @@ impl ResourceTaggingEntity {
         &self.tags
     }
 
-    pub fn get(self) -> (Vec<ResourceTaggingVO>, Vec<ResourceTaggingVO>, Vec<ResourceTaggingVO>) {
+    pub fn get(self) -> (Vec<ResourceTaggingVO>, Vec<ResourceTaggingVO>, Vec<TagID>) {
         (self.tags, self.add_tags, self.del_tags)
+    }
+
+    fn create_default_tagging_attr(tag: &Tag) -> ResourceTaggingAttrVO {
+        match tag.get_attr().clone() {
+            TagAttrVO::Normal => ResourceTaggingAttrVO::Normal,
+            TagAttrVO::WithNumber { defval, .. } => ResourceTaggingAttrVO::Number(defval),
+            TagAttrVO::WithText { defval } => ResourceTaggingAttrVO::Text(defval),
+            TagAttrVO::WithDate { defval } => ResourceTaggingAttrVO::Date(defval),
+            TagAttrVO::WithBool { defval } => ResourceTaggingAttrVO::Bool(defval),
+        }
+    }
+
+    fn create_tagging_attr(tag: &Tag, payload: TaggingAttrPayload) -> Result<ResourceTaggingAttrVO, ResourceGenericError> {
+        match tag.get_attr().clone() {
+            TagAttrVO::Normal => {
+                if let TaggingAttrPayload::None = payload {
+                    return Ok(ResourceTaggingAttrVO::Normal);
+                }
+                Err(ResourceGenericError::InvalidTaggingAttribute())
+            }
+            TagAttrVO::WithNumber { start, end, .. } => {
+                if let TaggingAttrPayload::Number(val) = payload {
+                    if val >= start && val <= end {
+                        return Ok(ResourceTaggingAttrVO::Number(val));
+                    }
+                }
+                Err(ResourceGenericError::InvalidTaggingAttribute())
+            },
+            TagAttrVO::WithText { .. } => {
+                if let TaggingAttrPayload::Text(val) = payload {
+                    return Ok(ResourceTaggingAttrVO::Text(val));
+                }
+                Err(ResourceGenericError::InvalidTaggingAttribute())
+            },
+            TagAttrVO::WithBool { .. } => {
+                if let TaggingAttrPayload::Bool(val) = payload {
+                    return Ok(ResourceTaggingAttrVO::Bool(val));
+                }
+                Err(ResourceGenericError::InvalidTaggingAttribute())
+            }
+            TagAttrVO::WithDate { .. } => {
+                if let TaggingAttrPayload::Date(val) = payload {
+                    if let Ok(date) = dateutils::parse(val) {
+                        return Ok(ResourceTaggingAttrVO::Date(date.and_utc()));
+                    }
+                }
+                Err(ResourceGenericError::InvalidTaggingAttribute())
+            },
+        }?
     }
 }

--- a/src-tauri/src/modules/resource/domain/entities/restag.rs
+++ b/src-tauri/src/modules/resource/domain/entities/restag.rs
@@ -10,9 +10,13 @@ use crate::modules::tag::domain::{Tag, TagID};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TaggingAttrPayload {
     None,
+
     Number(i64),
+
     Text(String),
+
     Date(String),
+
     Bool(bool),
 }
 
@@ -92,10 +96,10 @@ impl ResourceTaggingEntity {
     fn create_default_tagging_attr(tag: &Tag) -> ResourceTaggingAttrVO {
         match tag.get_attr().clone() {
             TagAttrVO::Normal => ResourceTaggingAttrVO::Normal,
-            TagAttrVO::WithNumber { defval, .. } => ResourceTaggingAttrVO::Number(defval),
-            TagAttrVO::WithText { defval } => ResourceTaggingAttrVO::Text(defval),
-            TagAttrVO::WithDate { defval } => ResourceTaggingAttrVO::Date(defval),
-            TagAttrVO::WithBool { defval } => ResourceTaggingAttrVO::Bool(defval),
+            TagAttrVO::Number { defval, .. } => ResourceTaggingAttrVO::Number(defval),
+            TagAttrVO::Text { defval } => ResourceTaggingAttrVO::Text(defval),
+            TagAttrVO::Date { defval } => ResourceTaggingAttrVO::Date(defval),
+            TagAttrVO::Bool { defval } => ResourceTaggingAttrVO::Bool(defval),
         }
     }
 
@@ -107,7 +111,7 @@ impl ResourceTaggingEntity {
                 }
                 Err(ResourceGenericError::InvalidTaggingAttribute())
             }
-            TagAttrVO::WithNumber { start, end, .. } => {
+            TagAttrVO::Number { start, end, .. } => {
                 if let TaggingAttrPayload::Number(val) = payload {
                     if val >= start && val <= end {
                         return Ok(ResourceTaggingAttrVO::Number(val));
@@ -115,19 +119,19 @@ impl ResourceTaggingEntity {
                 }
                 Err(ResourceGenericError::InvalidTaggingAttribute())
             },
-            TagAttrVO::WithText { .. } => {
+            TagAttrVO::Text { .. } => {
                 if let TaggingAttrPayload::Text(val) = payload {
                     return Ok(ResourceTaggingAttrVO::Text(val));
                 }
                 Err(ResourceGenericError::InvalidTaggingAttribute())
             },
-            TagAttrVO::WithBool { .. } => {
+            TagAttrVO::Bool { .. } => {
                 if let TaggingAttrPayload::Bool(val) = payload {
                     return Ok(ResourceTaggingAttrVO::Bool(val));
                 }
                 Err(ResourceGenericError::InvalidTaggingAttribute())
             }
-            TagAttrVO::WithDate { .. } => {
+            TagAttrVO::Date { .. } => {
                 if let TaggingAttrPayload::Date(val) = payload {
                     if let Ok(date) = dateutils::parse(val) {
                         return Ok(ResourceTaggingAttrVO::Date(date.and_utc()));

--- a/src-tauri/src/modules/resource/domain/entities/restag.rs
+++ b/src-tauri/src/modules/resource/domain/entities/restag.rs
@@ -89,8 +89,8 @@ impl ResourceTaggingEntity {
         &self.tags
     }
 
-    pub fn get(self) -> (Vec<ResourceTaggingVO>, Vec<ResourceTaggingVO>, Vec<TagID>) {
-        (self.tags, self.add_tags, self.del_tags)
+    pub fn take(self) -> (Vec<ResourceTaggingVO>, Vec<ResourceTaggingVO>, Vec<ResourceTaggingVO>, Vec<TagID>) {
+        (self.tags, self.add_tags, self.update_tags, self.del_tags)
     }
 
     fn create_default_tagging_attr(tag: &Tag) -> ResourceTaggingAttrVO {

--- a/src-tauri/src/modules/resource/domain/error.rs
+++ b/src-tauri/src/modules/resource/domain/error.rs
@@ -33,6 +33,9 @@ pub enum ResourceError {
     #[error("Remove tag")]
     RemoveTag(Error),
 
+    #[error("update tag")]
+    UpdateTag(Error),
+
     #[error("Explore file failed")]
     ExploreFile(Error),
 }
@@ -52,6 +55,7 @@ impl Serialize for ResourceError {
             ResourceError::QueryingByString(source) => serialize_error!(self, source),
             ResourceError::AddTag(source) => serialize_error!(self, source),
             ResourceError::RemoveTag(source) => serialize_error!(self, source),
+            ResourceError::UpdateTag(source) => serialize_error!(self, source),
             ResourceError::ExploreFile(source) => serialize_error!(self, source),
         };
         error_message.serialize(serializer)

--- a/src-tauri/src/modules/resource/domain/error.rs
+++ b/src-tauri/src/modules/resource/domain/error.rs
@@ -84,6 +84,9 @@ pub enum ResourceGenericError {
     #[error("Tag that dose not exists")]
     TagNotExists(),
 
+    #[error("Invalid tagging attribute with tag")]
+    InvalidTaggingAttribute(),
+
     #[error("Find the ambiguous tags")]
     FindAmbiguousTags(),
 

--- a/src-tauri/src/modules/resource/domain/mod.rs
+++ b/src-tauri/src/modules/resource/domain/mod.rs
@@ -11,7 +11,7 @@ mod error;
 pub use error::ResourceError;
 pub use error::ResourceGenericError;
 mod plainobj;
-pub use plainobj::{ResourcePlainObject, ResourceTaggingPlainObject};
+pub use plainobj::{ResourcePlainObject, ResourceTaggingPlainObject, ResourceTaggingAttrPlainObject};
 
 pub mod valueobj;
 use valueobj::{ResourceFileVO, ResourceUrlVO};
@@ -20,6 +20,7 @@ mod factory;
 pub use factory::ResourceFactory;
 
 use self::entities::ResourceTaggingEntity;
+use self::valueobj::ResourceTaggingAttrVO;
 pub mod entities;
 
 // =====================================================
@@ -90,9 +91,22 @@ impl ToPlainObject<ResourcePlainObject> for Resource {
         let tags = self.tagging
             .vals()
             .into_iter()
-            .map(move |x| ResourceTaggingPlainObject {
-                id: x.id.clone(),
-                added_at: dateutils::format(x.added_at),
+            .map(move |x| {
+                let attrval = match x.attrval.clone() {
+                    ResourceTaggingAttrVO::Normal => ResourceTaggingAttrPlainObject::Normal,
+                    ResourceTaggingAttrVO::Number(val) => ResourceTaggingAttrPlainObject::Number(val),
+                    ResourceTaggingAttrVO::Text(val) => ResourceTaggingAttrPlainObject::Text(val),
+                    ResourceTaggingAttrVO::Date(val) => {
+                        ResourceTaggingAttrPlainObject::Date(dateutils::format(val))
+                    },
+                    ResourceTaggingAttrVO::Bool(val) => ResourceTaggingAttrPlainObject::Bool(val),
+                };
+
+                ResourceTaggingPlainObject {
+                    id: x.id.clone(),
+                    added_at: dateutils::format(x.added_at),
+                    attrval: attrval,
+                }
             })
             .collect::<Vec<ResourceTaggingPlainObject>>();
 

--- a/src-tauri/src/modules/resource/domain/plainobj.rs
+++ b/src-tauri/src/modules/resource/domain/plainobj.rs
@@ -7,20 +7,16 @@ use super::ResourceID;
 
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(tag = "tagging_type", content = "attr")]
+#[serde(rename_all = "snake_case")]
 pub enum ResourceTaggingAttrPlainObject {
-    #[serde(rename = "normal")]
     Normal,
 
-    #[serde(rename = "number")]
     Number(i64),
 
-    #[serde(rename = "text")]
     Text(String),
 
-    #[serde(rename = "date")]
     Date(String),
 
-    #[serde(rename = "bool")]
     Bool(bool),
 }
 

--- a/src-tauri/src/modules/resource/domain/plainobj.rs
+++ b/src-tauri/src/modules/resource/domain/plainobj.rs
@@ -6,9 +6,32 @@ use super::ResourceID;
 
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "tagging_type", content = "attr")]
+pub enum ResourceTaggingAttrPlainObject {
+    #[serde(rename = "normal")]
+    Normal,
+
+    #[serde(rename = "number")]
+    Number(i64),
+
+    #[serde(rename = "text")]
+    Text(String),
+
+    #[serde(rename = "date")]
+    Date(String),
+
+    #[serde(rename = "bool")]
+    Bool(bool),
+}
+
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ResourceTaggingPlainObject {
     pub id: TagID,
+
     pub added_at: String,
+
+    #[serde(flatten)]
+    pub attrval: ResourceTaggingAttrPlainObject,
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/src-tauri/src/modules/resource/domain/valueobj/taggingvo.rs
+++ b/src-tauri/src/modules/resource/domain/valueobj/taggingvo.rs
@@ -6,9 +6,13 @@ use crate::modules::tag::domain::TagID;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ResourceTaggingAttrVO {
     Normal,
+
     Number(i64),
+
     Text(String),
+
     Date(DateTime<Utc>),
+
     Bool(bool),
 }
 

--- a/src-tauri/src/modules/resource/domain/valueobj/taggingvo.rs
+++ b/src-tauri/src/modules/resource/domain/valueobj/taggingvo.rs
@@ -1,19 +1,30 @@
 use chrono::{DateTime, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::modules::tag::domain::TagID;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ResourceTaggingAttrVO {
+    Normal,
+    Number(i64),
+    Text(String),
+    Date(DateTime<Utc>),
+    Bool(bool),
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ResourceTaggingVO {
     pub id: TagID,
     pub added_at: DateTime<Utc>,
+    pub attrval: ResourceTaggingAttrVO,
 }
 
 impl ResourceTaggingVO {
-    pub fn new<S: Into<String>>(tag_id: S) -> Self {
+    pub fn new<S: Into<String>>(tag_id: S, attrval: ResourceTaggingAttrVO) -> Self {
         Self {
             id: TagID::from(tag_id.into()),
             added_at: Utc::now(),
+            attrval: attrval,
         }
     }
 }

--- a/src-tauri/src/modules/resource/infrastructure/domapper.rs
+++ b/src-tauri/src/modules/resource/infrastructure/domapper.rs
@@ -2,21 +2,45 @@ use surrealdb::sql::Datetime;
 
 use crate::modules::common::domain::DomainModelMapper;
 use crate::modules::resource::domain::entities::ResourceTaggingEntity;
-use crate::modules::resource::domain::valueobj::{ResourceFileVO, ResourceTaggingVO, ResourceUrlVO};
+use crate::modules::resource::domain::valueobj::{ResourceFileVO, ResourceTaggingAttrVO, ResourceTaggingVO, ResourceUrlVO};
 use crate::modules::resource::domain::ResourceProps;
-use crate::modules::resource::repository::{ResourceDO, ResourceFileDo, ResourceTaggingDo, ResourceUrlDo};
+use crate::modules::resource::repository::{ResourceDO, ResourceFileDo, ResourceTaggingAttrDO, ResourceTaggingDo, ResourceUrlDo};
+
+impl DomainModelMapper<ResourceTaggingAttrVO> for ResourceTaggingAttrDO {
+    fn to_domain(self) -> ResourceTaggingAttrVO {
+        match self {
+            Self::Normal() => ResourceTaggingAttrVO::Normal,
+            Self::Number(val) => ResourceTaggingAttrVO::Number(val),
+            Self::Text(val) => ResourceTaggingAttrVO::Text(val),
+            Self::Date(val) => ResourceTaggingAttrVO::Date(val.0),
+            Self::Bool(val) => ResourceTaggingAttrVO::Bool(val),
+        }
+    }
+
+    fn from_domain(value: ResourceTaggingAttrVO) -> Self {
+        match value {
+            ResourceTaggingAttrVO::Normal => Self::Normal(),
+            ResourceTaggingAttrVO::Number(val) => Self::Number(val),
+            ResourceTaggingAttrVO::Text(val) => Self::Text(val),
+            ResourceTaggingAttrVO::Date(val) => Self::Date(Datetime(val)),
+            ResourceTaggingAttrVO::Bool(val) => Self::Bool(val),
+        }
+    }
+}
 
 impl DomainModelMapper<ResourceTaggingVO> for ResourceTaggingDo {
     fn to_domain(self) -> ResourceTaggingVO {
         ResourceTaggingVO {
             id: self.id.into(),
             added_at: self.added_at.0,
+            attrval: self.attrval.to_domain(),
         }
     }
     fn from_domain(value: ResourceTaggingVO) -> Self {
         Self {
             id: value.id.into(),
-            added_at: Datetime(value.added_at)
+            added_at: Datetime(value.added_at),
+            attrval: ResourceTaggingAttrDO::from_domain(value.attrval),
         }
     }
 }

--- a/src-tauri/src/modules/resource/infrastructure/stringql/attrval.rs
+++ b/src-tauri/src/modules/resource/infrastructure/stringql/attrval.rs
@@ -1,0 +1,192 @@
+use std::fmt::Debug;
+use std::num::{IntErrorKind, ParseIntError};
+
+use chrono::NaiveDate;
+use strum_macros::EnumDiscriminants;
+
+#[derive(thiserror::Error, Debug)]
+pub enum AttributeParseError {
+    #[error("Multiple range found")]
+    MultipleRangeFound,
+
+    #[error("Invalid range number format")]
+    InvalidRangeNumberFormat,
+
+    #[error("Range numeber start is larger than the end")]
+    NumberStartIsLargerThanEnd,
+
+    #[error("Invalid range date format")]
+    InvalidRangeDateFormat,
+    
+    #[error("Range date start is larger than the end")]
+    DateStartIsLargerThenEnd,
+
+    #[error("Invalid bool format")]
+    InvalidBoolFormat,
+
+    #[error("Range is empty")]
+    RangeEmpty,
+}
+
+
+// ---------------------------------------------------------
+#[derive(Debug, Clone, PartialEq, EnumDiscriminants)]
+#[strum_discriminants(name(AttributeValueType))]
+pub enum AttributeValue {
+    Text(String),
+    OptionText(Option<String>),
+    NumberRange(Option<usize>, Option<usize>),
+    DateRange(Option<NaiveDate>, Option<NaiveDate>),
+    Bool(bool),
+    None,
+}
+impl AttributeValue {
+
+    fn parse_bool(value: &str) -> Result<Self, AttributeParseError> {
+        Ok(match value {
+            "" => Self::Bool(true),
+            "true" | "1" => Self::Bool(true),
+            "false" | "0" => Self::Bool(false),
+            _ => Err(AttributeParseError::InvalidBoolFormat)?,
+        })
+    }
+
+    fn parse_number_range(value: &str) -> Result<Self, AttributeParseError> {
+        // single number
+        if let Ok(num) = value.parse::<usize>() {
+            return Ok(Self::NumberRange(Some(num), Some(num)));
+        }
+
+        let nums = Self::get_range(value)?
+            .iter()
+            .map(|val| {
+                val.parse::<i64>()
+                    .or_else(|x| match x.kind() { IntErrorKind::Empty => Ok(-1), _ => Err(x) })
+                    .and_then(|x| match x {
+                        x if x >= 0 => Ok(Some(x as usize)),
+                        _ => Ok(None),
+                    })
+            })
+            .collect::<Vec<Result<Option<usize>, ParseIntError>>>();
+
+        if !nums.iter().all(Result::is_ok) {
+            return Err(AttributeParseError::InvalidRangeNumberFormat);
+        }
+
+        let nums: Vec<_> = nums.into_iter().map(|x| x.unwrap()).collect();
+        if nums.iter().all(Option::is_none) {
+            return Err(AttributeParseError::RangeEmpty);
+        }
+
+        if let (Some(start), Some(end)) = (nums[0], nums[1]) {
+            if start > end {
+                return Err(AttributeParseError::NumberStartIsLargerThanEnd);
+            }
+        }
+
+        Ok(Self::NumberRange(nums[0], nums[1]))
+    }
+
+    fn parse_date_range(value: &str) -> Result<Self, AttributeParseError> {
+        // single date
+        if let Ok(val) = NaiveDate::parse_from_str(value, "%Y/%m/%d") {
+            return Ok(Self::DateRange(Some(val), Some(val)));
+        }
+
+        let date = Self::get_range(value)?
+            .iter()
+            .map(|val| {
+                if let Ok(date) = NaiveDate::parse_from_str(val, "%Y/%m/%d") {
+                    return Ok(Some(date))
+                }
+                if val.is_empty() {
+                    return Ok(None)
+                }
+                Err(())
+            })
+            .collect::<Vec<Result<Option<NaiveDate>, ()>>>();
+    
+        if !date.iter().all(Result::is_ok) {
+            return Err(AttributeParseError::InvalidRangeDateFormat);
+        }
+
+        let date: Vec<_> = date.into_iter().map(|x| x.unwrap()).collect();
+        if date.iter().all(Option::is_none) {
+            return Err(AttributeParseError::RangeEmpty);
+        }
+
+        if let (Some(start), Some(end)) = (date[0], date[1]) {
+            if start > end {
+                return Err(AttributeParseError::DateStartIsLargerThenEnd);
+            }
+        }
+
+        Ok(Self::DateRange(date[0], date[1].to_owned()))
+    }
+
+    /// separate the range from string
+    /// 
+    /// ### example:
+    /// ```
+    /// let range1 = get_range("1..45");
+    /// let range2 = get_range("1..");
+    /// let range3 = get_range("1..15..40");
+    /// 
+    /// assert_eq!(range1, Ok(vect!["1", "45"])); 
+    /// assert_eq!(range1, Ok(vect!["1", ""])); 
+    /// assert_eq!(range1, Err(AttributeParseError::MultipleRangeFound)); 
+    /// ```
+    fn get_range(val: &str) -> Result<Vec<&str>, AttributeParseError> {
+        let separated: Vec<&str> = val.split("..").collect();
+        if separated.len() == 2 {
+            return Ok(vec![separated.get(0).unwrap(), separated.get(1).unwrap()]);
+        }
+        if separated.len() > 2 {
+            return Err(AttributeParseError::MultipleRangeFound)
+        }
+        Err(AttributeParseError::MultipleRangeFound)
+    }
+
+    /// depend on `AttributeValueType` and converte val to `AttributeValue`
+    /// ### example:
+    /// ```
+    /// let a = parse_from("45", AttributeValueType.Text);
+    /// let b = parse_from("..45", AttributeValueType.NumberRange);
+    /// let c = parse_from("2021/06/23..", AttributeValueType.DateRange);
+    /// 
+    /// assert_eq!(a, Ok(AttributeValue::Text("45".to_string())));
+    /// assert_eq!(b, Ok(AttributeValue::NumberRange(None, Some(45))));
+    /// assert_eq!(c, Ok(AttributeValue::DateRange(Some("2021/06/23..".to_string()), None)));
+    /// ```
+    pub fn parse_from<T: Into<String>>(s: T, attr_type: AttributeValueType) -> Result<Self, AttributeParseError> {
+        let val = s.into();
+        match attr_type {
+            AttributeValueType::Text => {
+                Ok(Self::Text(val))
+            },
+            AttributeValueType::OptionText => {
+                Ok(Self::OptionText(
+                    match !val.is_empty() {
+                        true => Some(val),
+                        false => None,
+                    }
+                ))
+            },
+            AttributeValueType::NumberRange => {
+                let result = Self::parse_number_range(&val)?;
+                Ok(result)
+            },
+            AttributeValueType::DateRange => {
+                let result = Self::parse_date_range(&val)?;
+                Ok(result)
+            },
+            AttributeValueType::Bool => {
+                let result = Self::parse_bool(&val)?;
+                Ok(result)
+            },
+            AttributeValueType::None => {
+                Ok(Self::None)
+            }
+        }
+    }
+}

--- a/src-tauri/src/modules/resource/infrastructure/stringql/mod.rs
+++ b/src-tauri/src/modules/resource/infrastructure/stringql/mod.rs
@@ -81,8 +81,13 @@ impl From<StringQLObject> for ResourceStringQL {
                 StringQLPrefix::Exclude =>  group_items.join(" AND "),
                 StringQLPrefix::Inherit => group_items.join(" OR "),
             };
+            let not_flag = match group.prefix {
+                StringQLPrefix::Include => false,
+                StringQLPrefix::Exclude => true,
+                StringQLPrefix::Inherit => false,
+            };
 
-            q.push(group_result);
+            q.push(sql_utils::sql_with_prefix(not_flag, format!("({})", group_result)));
         }
 
         Self { qlstr: q.join(" AND ") }

--- a/src-tauri/src/modules/resource/infrastructure/stringql/mod.rs
+++ b/src-tauri/src/modules/resource/infrastructure/stringql/mod.rs
@@ -2,8 +2,13 @@
 mod qlobj;
 pub use qlobj::*;
 
+mod attrval;
+pub use attrval::*;
+
 mod systags;
 pub use systags::SystemTag;
+
+use crate::modules::common::repository::sql_utils;
 
 /// Generate String Querying Language \
 /// This is depend on SurrealDB
@@ -16,80 +21,71 @@ impl ResourceStringQL {
     pub fn get(&self) -> String {
         self.qlstr.clone()
     }
+
+    pub fn item_to_qlstring(item: &StringQLItem) -> String {
+        let attribute = item.get_attribute().clone().unwrap_or(AttributeValue::None);
+        let value = item.get_value();
+
+        let not_flag = match item.get_prefix() {
+            StringQLPrefix::Include => false,
+            StringQLPrefix::Exclude => true,
+            StringQLPrefix::Inherit => false,
+        };
+
+        // system tag
+        if *item.is_system() {
+            if let Ok(function_tag) = SystemTag::from_str(value, attribute) {
+                return sql_utils::sql_with_prefix(not_flag, function_tag.to_qlstring());
+            }
+            panic!("Invalid SystemTag!");
+        }
+        // normal
+        else {
+            let tagging = format!("(<-(tagging WHERE in == {}).attrval)[0]", value);
+            let ql = match attribute {
+                AttributeValue::None => sql_utils::sql_contain("<-tagging.in", value),
+                AttributeValue::Text(text) => sql_utils::sql_contain_string(&tagging, text),
+                AttributeValue::OptionText(text) => {
+                    match text {
+                        Some(val) => sql_utils::sql_contain_string(&tagging, val),
+                        None => sql_utils::sql_contain("<-tagging.in", value),
+                    }
+                },
+                AttributeValue::NumberRange(start, end) => sql_utils::sql_range_number(&tagging, (&start, &end)),
+                AttributeValue::DateRange(start, end) => sql_utils::sql_range_date(&tagging, (&start, &end)),
+                AttributeValue::Bool(val) => sql_utils::sql_equal(&tagging, &val),
+            };
+
+            sql_utils::sql_with_prefix(not_flag, ql)
+        }
+    }
 }
 
 impl From<StringQLObject> for ResourceStringQL {
     fn from(qloject: StringQLObject) -> Self {
         let mut q: Vec<String> = Vec::new();
 
-        let mut contains_all: Vec<&str> = Vec::new();
-
-        let mut contains_not: Vec<&str> = Vec::new();
-
         for item in qloject.get_items() {
-            let attribute = item.get_attribute().clone().unwrap_or(AttributeValue::None);
-            
-            match item.get_prefix() {
-                StringQLPrefix::Include => {
-                    if let Ok(function_tag) = SystemTag::from_str(item.get_value(), attribute) {
-                        q.push(function_tag.to_qlstring(false));
-                    }
-                    else {
-                        contains_all.push(item.get_value());
-                    }
-                },
-                StringQLPrefix::Exclude => {
-                    if let Ok(function_tag) = SystemTag::from_str(item.get_value(), attribute) {
-                        q.push(function_tag.to_qlstring(true));
-                    }
-                    else {
-                        contains_not.push(item.get_value());
-                    }
-                },
-                StringQLPrefix::Inherit => {},
-            }
-        }
-
-        if !contains_all.is_empty() {
-            q.push(format!("(<-tagging<-tag.id CONTAINSALL [{}])", contains_all.join(", ")));
-        }
-
-        if !contains_not.is_empty() {
-            q.push(format!("!(<-tagging<-tag.id CONTAINSANY [{}])", contains_not.join(", ")));
+            let item_qlstring = ResourceStringQL::item_to_qlstring(&item);
+            q.push(item_qlstring);
         }
         
         for group in qloject.get_groups() {
-            let mut group_items: Vec<String> = Vec::new();
-            let mut pure_items: Vec<String> = Vec::new();
-
-            for item in group.items.iter() {
-                let attribute = item.get_attribute().clone().unwrap_or(AttributeValue::None);
-                if let Ok(system_tag) = SystemTag::from_str(item.get_value(), attribute) {
-                    group_items.push(system_tag.to_qlstring(false));
-                }
-                else {
-                    pure_items.push(item.get_value().to_string());
-                }
-            }
+            let group_items: Vec<String> = group.items.iter()
+                .map(|item| ResourceStringQL::item_to_qlstring(&item))
+                .collect();
             
             // determine the group prefix
-            match group.prefix {
-                StringQLPrefix::Include => {
-                    if !pure_items.is_empty() {
-                        group_items.push(format!("(<-tagging<-tag.id CONTAINSANY [{}])", pure_items.join(", ")));
-                    }
-                    q.push(format!("({})", group_items.join(" OR ")))
-                },
-                StringQLPrefix::Exclude => {
-                    if !pure_items.is_empty() {
-                        group_items.push(format!("(<-tagging<-tag.id CONTAINSALL [{}])", pure_items.join(", ")));
-                    }
-                    q.push(format!("!({})", group_items.join(" AND ")))
-                },
-                StringQLPrefix::Inherit => {}
-            }
+            let group_result =  match group.prefix {
+                StringQLPrefix::Include => group_items.join(" OR "),
+                StringQLPrefix::Exclude =>  group_items.join(" AND "),
+                StringQLPrefix::Inherit => group_items.join(" OR "),
+            };
+
+            q.push(group_result);
         }
 
         Self { qlstr: q.join(" AND ") }
     }
 }
+

--- a/src-tauri/src/modules/resource/infrastructure/stringql/qlobj.rs
+++ b/src-tauri/src/modules/resource/infrastructure/stringql/qlobj.rs
@@ -1,190 +1,5 @@
-use std::fmt::Debug;
-use std::num::{IntErrorKind, ParseIntError};
+use super::AttributeValue;
 
-use chrono::NaiveDate;
-
-#[derive(thiserror::Error, Debug)]
-pub enum AttributeParseError {
-    #[error("Multiple range found")]
-    MultipleRangeFound,
-
-    #[error("Invalid range number format")]
-    InvalidRangeNumberFormat,
-
-    #[error("Range numeber start is larger than the end")]
-    NumberStartIsLargerThanEnd,
-
-    #[error("Invalid range date format")]
-    InvalidRangeDateFormat,
-    
-    #[error("Range date start is larger than the end")]
-    DateStartIsLargerThenEnd,
-
-    #[error("Range is empty")]
-    RangeEmpty,
-}
-
-// ---------------------------------------------------------
-/// Defined type of attribute
-/// ```
-/// Text => String
-/// OptionText => Option<String>
-/// NumberRange => (Option<usize>, Option<usize>)
-/// DateRange => (Option<String>, Option<String>)
-/// ```
-#[derive(Debug, Clone, PartialEq)]
-pub enum AttributeValueType {
-    Text,
-    OptionText,
-    NumberRange,
-    DateRange,
-}
-
-// ---------------------------------------------------------
-#[derive(Debug, Clone, PartialEq)]
-pub enum AttributeValue {
-    Text(String),
-    OptionText(Option<String>),
-    NumberRange(Option<usize>, Option<usize>),
-    DateRange(Option<NaiveDate>, Option<NaiveDate>),
-    None,
-}
-impl AttributeValue {
-
-    fn parse_number_range(value: &str) -> Result<Self, AttributeParseError> {
-        // single number
-        if let Ok(num) = value.parse::<usize>() {
-            return Ok(Self::NumberRange(Some(num), Some(num)));
-        }
-
-        let nums = Self::get_range(value)?
-            .iter()
-            .map(|val| {
-                val.parse::<i64>()
-                    .or_else(|x| match x.kind() { IntErrorKind::Empty => Ok(-1), _ => Err(x) })
-                    .and_then(|x| match x {
-                        x if x >= 0 => Ok(Some(x as usize)),
-                        _ => Ok(None),
-                    })
-            })
-            .collect::<Vec<Result<Option<usize>, ParseIntError>>>();
-
-        if !nums.iter().all(Result::is_ok) {
-            return Err(AttributeParseError::InvalidRangeNumberFormat);
-        }
-
-        let nums: Vec<_> = nums.into_iter().map(|x| x.unwrap()).collect();
-        if nums.iter().all(Option::is_none) {
-            return Err(AttributeParseError::RangeEmpty);
-        }
-
-        if let (Some(start), Some(end)) = (nums[0], nums[1]) {
-            if start > end {
-                return Err(AttributeParseError::NumberStartIsLargerThanEnd);
-            }
-        }
-
-        Ok(Self::NumberRange(nums[0], nums[1]))
-    }
-
-    fn parse_date_range(value: &str) -> Result<Self, AttributeParseError> {
-        // single date
-        if let Ok(val) = NaiveDate::parse_from_str(value, "%Y/%m/%d") {
-            return Ok(Self::DateRange(Some(val), Some(val)));
-        }
-
-        let date = Self::get_range(value)?
-            .iter()
-            .map(|val| {
-                if let Ok(date) = NaiveDate::parse_from_str(val, "%Y/%m/%d") {
-                    return Ok(Some(date))
-                }
-                if val.is_empty() {
-                    return Ok(None)
-                }
-                Err(())
-            })
-            .collect::<Vec<Result<Option<NaiveDate>, ()>>>();
-    
-        if !date.iter().all(Result::is_ok) {
-            return Err(AttributeParseError::InvalidRangeDateFormat);
-        }
-
-        let date: Vec<_> = date.into_iter().map(|x| x.unwrap()).collect();
-        if date.iter().all(Option::is_none) {
-            return Err(AttributeParseError::RangeEmpty);
-        }
-
-        if let (Some(start), Some(end)) = (date[0], date[1]) {
-            if start > end {
-                return Err(AttributeParseError::DateStartIsLargerThenEnd);
-            }
-        }
-
-        Ok(Self::DateRange(date[0], date[1].to_owned()))
-    }
-
-    /// separate the range from string
-    /// 
-    /// ### example:
-    /// ```
-    /// let range1 = get_range("1..45");
-    /// let range2 = get_range("1..");
-    /// let range3 = get_range("1..15..40");
-    /// 
-    /// assert_eq!(range1, Ok(vect!["1", "45"])); 
-    /// assert_eq!(range1, Ok(vect!["1", ""])); 
-    /// assert_eq!(range1, Err(AttributeParseError::MultipleRangeFound)); 
-    /// ```
-    fn get_range(val: &str) -> Result<Vec<&str>, AttributeParseError> {
-        let separated: Vec<&str> = val.split("..").collect();
-        if separated.len() == 2 {
-            return Ok(vec![separated.get(0).unwrap(), separated.get(1).unwrap()]);
-        }
-        if separated.len() > 2 {
-            return Err(AttributeParseError::MultipleRangeFound)
-        }
-        Err(AttributeParseError::MultipleRangeFound)
-    }
-
-    /// depend on `AttributeValueType` and converte val to `AttributeValue`
-    /// ### example:
-    /// ```
-    /// let a = parse_from("45", AttributeValueType.Text);
-    /// let b = parse_from("..45", AttributeValueType.NumberRange);
-    /// let c = parse_from("2021/06/23..", AttributeValueType.DateRange);
-    /// 
-    /// assert_eq!(a, Ok(AttributeValue::Text("45".to_string())));
-    /// assert_eq!(b, Ok(AttributeValue::NumberRange(None, Some(45))));
-    /// assert_eq!(c, Ok(AttributeValue::DateRange(Some("2021/06/23..".to_string()), None)));
-    /// ```
-    pub fn parse_from<T: Into<String>>(s: T, attr_type: AttributeValueType) -> Result<Self, AttributeParseError> {
-        let val = s.into();
-        match attr_type {
-            AttributeValueType::Text => {
-                Ok(Self::Text(val))
-            },
-            AttributeValueType::OptionText => {
-                Ok(Self::OptionText(
-                    match !val.is_empty() {
-                        true => Some(val),
-                        false => None,
-                    }
-                ))
-            },
-            AttributeValueType::NumberRange => {
-                let result = Self::parse_number_range(&val)?;
-                Ok(result)
-            },
-            AttributeValueType::DateRange => {
-                let result = Self::parse_date_range(&val)?;
-                Ok(result)
-            },
-        }
-    }
-}
-
-// ---------------------------------------------------------
 #[derive(Debug, Clone)]
 pub enum StringQLPrefix {
     Include,
@@ -197,17 +12,23 @@ pub enum StringQLPrefix {
 pub struct StringQLItem {
     prefix: StringQLPrefix,
 
+    is_system: bool,
+
     value: String,
 
     attribute: Option<AttributeValue>,
 }
 impl StringQLItem {
-    pub fn new( prefix: StringQLPrefix, value: String, attribute: Option<AttributeValue>) -> Self {
-        Self { prefix, value, attribute }
+    pub fn new( prefix: StringQLPrefix, value: String, attribute: Option<AttributeValue>, is_system: bool) -> Self {
+        Self { prefix, value, attribute, is_system }
     }
 
     pub fn get_attribute(&self) -> &Option<AttributeValue> {
         &self.attribute
+    }
+
+    pub fn is_system(&self) -> &bool {
+        &self.is_system
     }
 
     pub fn get_value(&self) -> &String {
@@ -250,7 +71,6 @@ impl StringQLObject {
     pub fn get_groups(&self) ->  &Vec<StringQLGroup> {
         &self.groups
     }
-    
 }
 
 // ---------------------------------------------------------

--- a/src-tauri/src/modules/resource/repository/data_model.rs
+++ b/src-tauri/src/modules/resource/repository/data_model.rs
@@ -15,36 +15,23 @@ pub struct ResourceUrlDo {
     pub full: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, strum_macros::Display)]
 #[serde(tag = "tagging_type", content = "attrval")]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum ResourceTaggingAttrDO {
-    #[serde(rename = "normal")]
     #[serde(deserialize_with = "ResourceTaggingAttrDO::deserialize_null_default")]
     Normal(),
 
-    #[serde(rename = "number")]
     Number(i64),
 
-    #[serde(rename = "text")]
     Text(String),
 
-    #[serde(rename = "date")]
     Date(Datetime),
 
-    #[serde(rename = "bool")]
     Bool(bool),
 }
 impl ResourceTaggingAttrDO {
-    pub fn get_type_name(&self) -> String {
-        match self {
-            Self::Normal() => "normal",
-            Self::Number(..) => "number",
-            Self::Text(..) => "text",
-            Self::Date(..) => "date",
-            Self::Bool(..) => "bool",
-        }.to_string()
-    }
-
     fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
     where
         T: Default + Deserialize<'de>,

--- a/src-tauri/src/modules/resource/repository/data_model.rs
+++ b/src-tauri/src/modules/resource/repository/data_model.rs
@@ -1,0 +1,101 @@
+use serde::{Deserialize, Deserializer, Serialize};
+use surrealdb::sql::{Datetime, Thing, Value};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ResourceFileDo {
+    pub uuid: String,
+    pub name: String,
+    pub path: String,
+    pub ext: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ResourceUrlDo {
+    pub host: String,
+    pub full: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "tagging_type", content = "attrval")]
+pub enum ResourceTaggingAttrDO {
+    #[serde(rename = "normal")]
+    #[serde(deserialize_with = "ResourceTaggingAttrDO::deserialize_null_default")]
+    Normal(),
+
+    #[serde(rename = "number")]
+    Number(i64),
+
+    #[serde(rename = "text")]
+    Text(String),
+
+    #[serde(rename = "date")]
+    Date(Datetime),
+
+    #[serde(rename = "bool")]
+    Bool(bool),
+}
+impl ResourceTaggingAttrDO {
+    pub fn get_type_name(&self) -> String {
+        match self {
+            Self::Normal() => "normal",
+            Self::Number(..) => "number",
+            Self::Text(..) => "text",
+            Self::Date(..) => "date",
+            Self::Bool(..) => "bool",
+        }.to_string()
+    }
+
+    fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+    where
+        T: Default + Deserialize<'de>,
+        D: Deserializer<'de>,
+    {
+        let opt = Option::deserialize(deserializer)?;
+        Ok(opt.unwrap_or_default())
+    }
+}
+impl Into<Value> for ResourceTaggingAttrDO {
+    fn into(self) -> Value {    
+        match self {
+            Self::Normal() => Value::Null,
+            Self::Number(val) => Value::Number(val.into()),
+            Self::Text(val) => Value::Strand(val.into()),
+            Self::Date(val) => Value::Datetime(val.into()),
+            Self::Bool(val) => Value::Bool(val.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ResourceTaggingDo {
+    #[serde(alias = "in")]
+    pub id: Thing,
+
+    pub added_at: Datetime,
+
+    #[serde(flatten)]
+    pub attrval: ResourceTaggingAttrDO,
+}
+
+/**
+ * Resource Data Object */
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ResourceDO {
+    pub id: Thing,
+    pub name: String,
+    pub description: String,
+    pub file: Option<ResourceFileDo>,
+    pub url: Option<ResourceUrlDo>,
+    pub auth: bool,
+    pub created_at: Datetime,
+    pub updated_at: Datetime,
+    pub belong_category: Thing,
+    
+    #[serde(skip_serializing)]
+    #[serde(default = "String::default")]
+    pub root_path: String,
+
+    #[serde(skip_serializing)]
+    #[serde(default = "Vec::new")]
+    pub tags: Vec<ResourceTaggingDo>,
+}

--- a/src-tauri/src/modules/resource/repository/mod.rs
+++ b/src-tauri/src/modules/resource/repository/mod.rs
@@ -8,3 +8,6 @@ pub use relation::{RESOURCE_TAG_RELATION_REPOSITORY, ResourceTagRelationReposito
 
 mod repository;
 pub use repository::*;
+
+mod data_model;
+pub use data_model::*;

--- a/src-tauri/src/modules/resource/repository/query-repository.rs
+++ b/src-tauri/src/modules/resource/repository/query-repository.rs
@@ -71,14 +71,15 @@ impl<'a> ResourceQueryRepository<'a> {
                 *,
                 (->belong->subject.name)[0] AS subject_name,
                 (->tagging.added_at)[0] AS added_at,
+                (->tagging.attrval)[0] AS attrval,
                 array::len(->tagging.out) as tagged_count
                 FROM tag 
                 WHERE ->tagging->resource.id CONTAINS $parent.id
                 ORDER BY added_at ASC
             ) AS tags
             FROM type::table($table)
-            WHERE id == $id"#, 
-            Self::ROOT_PATH_FIELD);
+            WHERE id == $id
+        "#, Self::ROOT_PATH_FIELD);
                     
         let result: Option<ResourceDetailDto> = self.db
             .query(sql)

--- a/src-tauri/src/modules/resource/repository/relation-repository.rs
+++ b/src-tauri/src/modules/resource/repository/relation-repository.rs
@@ -65,7 +65,7 @@ impl<'a> ResourceTagRelationRepository<'a> {
 
             let mut content: BTreeMap<&str, Value> = BTreeMap::new();
             content.insert("added_at", Value::Datetime(tag.added_at.into()));
-            content.insert("tagging_type", Value::Strand(tag.attrval.get_type_name().into()));
+            content.insert("tagging_type", Value::Strand(tag.attrval.to_string().into()));
             content.insert("attrval", tag.attrval.into());
 
             self.create_relation(&tag.id.to_string(), &resource_id, content.into()).await?

--- a/src-tauri/src/modules/resource/repository/repository.rs
+++ b/src-tauri/src/modules/resource/repository/repository.rs
@@ -1,7 +1,6 @@
 use once_cell::sync::Lazy;
-use serde::{Deserialize, Serialize};
 use surrealdb::Surreal;
-use surrealdb::sql::{Datetime, Thing, thing};
+use surrealdb::sql::{Thing, thing};
 use surrealdb::engine::remote::ws::Client;
 
 use crate::modules::common::domain::DomainModelMapper;
@@ -10,6 +9,7 @@ use crate::modules::common::repository::{env, CommonRepository, COMMON_REPOSITOR
 use crate::modules::common::repository::tablens;
 use crate::modules::resource::domain::{Resource, ResourceFactory, ResourceID};
 
+use super::ResourceDO;
 use super::{RESOURCE_TAG_RELATION_REPOSITORY, ResourceTagRelationRepository};
 
 pub static RESOURCE_REPOSITORY: ResourceRepository<'_> = ResourceRepository::init(
@@ -17,51 +17,6 @@ pub static RESOURCE_REPOSITORY: ResourceRepository<'_> = ResourceRepository::ini
     &COMMON_REPOSITORY, 
     &RESOURCE_TAG_RELATION_REPOSITORY
 );
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ResourceFileDo {
-    pub uuid: String,
-    pub name: String,
-    pub path: String,
-    pub ext: String,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ResourceUrlDo {
-    pub host: String,
-    pub full: String,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ResourceTaggingDo {
-    #[serde(alias = "in")]
-    pub id: Thing,
-
-    pub added_at: Datetime,
-}
-
-/**
- * Resource Data Object */
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ResourceDO {
-    pub id: Thing,
-    pub name: String,
-    pub description: String,
-    pub file: Option<ResourceFileDo>,
-    pub url: Option<ResourceUrlDo>,
-    pub auth: bool,
-    pub created_at: Datetime,
-    pub updated_at: Datetime,
-    pub belong_category: Thing,
-    
-    #[serde(skip_serializing)]
-    #[serde(default = "String::default")]
-    pub root_path: String,
-
-    #[serde(skip_serializing)]
-    #[serde(default = "Vec::new")]
-    pub tags: Vec<ResourceTaggingDo>,
-}
 
 /**
  * Repository */

--- a/src-tauri/src/modules/tag/application/command/create_tag/dto.rs
+++ b/src-tauri/src/modules/tag/application/command/create_tag/dto.rs
@@ -1,5 +1,26 @@
 use serde::{Serialize, Deserialize};
 
+// Quick Example: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=15cfab66d38ff8a15a9cf1d8d897ac68
+// See also: https://serde.rs/enum-representations.html
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "tag_type", content = "attr")]
+pub enum CreateTagTypeDto {
+    #[serde(rename = "normal")]
+    Normal,
+
+    #[serde(rename = "number")]
+    Number { start: i64, end: i64, defval: i64 },
+
+    #[serde(rename = "text")]
+    Text { defval: String },
+
+    #[serde(rename = "date")]
+    Date { defval: String },
+
+    #[serde(rename = "bool")]
+    Bool { defval: bool },
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct CreateTagDto {
     pub name: String,
@@ -9,4 +30,7 @@ pub struct CreateTagDto {
     pub belong_category: String,
 
     pub belong_subject: String,
+
+    #[serde(flatten)]
+    pub attrval: CreateTagTypeDto,
 }

--- a/src-tauri/src/modules/tag/application/command/create_tag/dto.rs
+++ b/src-tauri/src/modules/tag/application/command/create_tag/dto.rs
@@ -1,25 +1,5 @@
 use serde::{Serialize, Deserialize};
-
-// Quick Example: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=15cfab66d38ff8a15a9cf1d8d897ac68
-// See also: https://serde.rs/enum-representations.html
-#[derive(Serialize, Deserialize)]
-#[serde(tag = "tag_type", content = "attr")]
-pub enum CreateTagTypeDto {
-    #[serde(rename = "normal")]
-    Normal,
-
-    #[serde(rename = "number")]
-    Number { start: i64, end: i64, defval: i64 },
-
-    #[serde(rename = "text")]
-    Text { defval: String },
-
-    #[serde(rename = "date")]
-    Date { defval: String },
-
-    #[serde(rename = "bool")]
-    Bool { defval: bool },
-}
+use crate::modules::tag::application::dto::TagAttrDto;
 
 #[derive(Serialize, Deserialize)]
 pub struct CreateTagDto {
@@ -32,5 +12,5 @@ pub struct CreateTagDto {
     pub belong_subject: String,
 
     #[serde(flatten)]
-    pub attrval: CreateTagTypeDto,
+    pub attrval: TagAttrDto,
 }

--- a/src-tauri/src/modules/tag/application/command/create_tag/mod.rs
+++ b/src-tauri/src/modules/tag/application/command/create_tag/mod.rs
@@ -7,6 +7,7 @@ use crate::modules::category::domain::CategoryID;
 use crate::modules::category::repository::CategoryRepository;
 use crate::modules::subject::domain::SubjectID;
 use crate::modules::subject::repository::SubjectRepository;
+use crate::modules::tag::application::dto::TagAttrDto;
 use crate::modules::tag::domain::{TagFactory, TagGenericError, TagID};
 use crate::modules::tag::domain::valueobj::TagAttributeFactory;
 use crate::modules::tag::repository::TagRepository;
@@ -26,7 +27,7 @@ pub struct CreateTagCommand {
     pub belong_subject: String,
 
     #[serde(flatten)]
-    pub attrval: CreateTagTypeDto,
+    pub attrval: TagAttrDto,
 }
 command_from_dto!(CreateTagCommand, CreateTagDto);
 
@@ -77,11 +78,11 @@ impl ICommandHandler<CreateTagCommand> for CreateTagHandler<'_> {
 
         // create tag attribute
         let new_attr = match attrval {
-            CreateTagTypeDto::Normal => TagAttributeFactory::create_normal(),
-            CreateTagTypeDto::Number { start, end, defval } => TagAttributeFactory::create_number(start, end, defval),
-            CreateTagTypeDto::Text { defval } => TagAttributeFactory::create_text(defval),
-            CreateTagTypeDto::Date { defval } => TagAttributeFactory::create_date(defval),
-            CreateTagTypeDto::Bool { defval } => TagAttributeFactory::create_bool(defval),
+            TagAttrDto::Normal => TagAttributeFactory::create_normal(),
+            TagAttrDto::Number { start, end, defval } => TagAttributeFactory::create_number(start, end, defval),
+            TagAttrDto::Text { defval } => TagAttributeFactory::create_text(defval),
+            TagAttrDto::Date { defval } => TagAttributeFactory::create_date(defval),
+            TagAttrDto::Bool { defval } => TagAttributeFactory::create_bool(defval),
         }?;
 
         // create new tag

--- a/src-tauri/src/modules/tag/application/command/create_tag/mod.rs
+++ b/src-tauri/src/modules/tag/application/command/create_tag/mod.rs
@@ -91,8 +91,6 @@ impl ICommandHandler<CreateTagCommand> for CreateTagHandler<'_> {
         let result = self.tag_repo
             .save(new_tag)
             .await;
-
-        dbg!(&result);
         
         match result {
             Ok(value) => Ok(value.take_id()),

--- a/src-tauri/src/modules/tag/application/dto/response.rs
+++ b/src-tauri/src/modules/tag/application/dto/response.rs
@@ -4,6 +4,29 @@ use surrealdb::sql::Thing;
 use crate::modules::common::application::thing_serialize;
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "tag_type", content = "attr")]
+pub enum TagAttrResDto {
+    #[serde(rename = "normal")]
+    Normal,
+
+    #[serde(rename = "number")]
+    WithNumber {
+        start: i64,
+        end: i64,
+        defval: i64,
+    },
+
+    #[serde(rename = "text")]
+    WithText { defval: String },
+
+    #[serde(rename = "date")]
+    WithDate { defval: String },
+
+    #[serde(rename = "bool")]
+    WithBool { defval: bool },
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct TagResDto {
     #[serde(serialize_with = "thing_serialize")]
     pub id: Thing,
@@ -25,6 +48,9 @@ pub struct TagResDto {
     pub subject_name: String,
 
     pub auth: bool,
+
+    #[serde(flatten)]
+    pub attrval: TagAttrResDto,
 
     pub created_at: String,
 

--- a/src-tauri/src/modules/tag/application/dto/response.rs
+++ b/src-tauri/src/modules/tag/application/dto/response.rs
@@ -3,27 +3,21 @@ use surrealdb::sql::Thing;
 
 use crate::modules::common::application::thing_serialize;
 
+// Quick Example: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=15cfab66d38ff8a15a9cf1d8d897ac68
+// See also: https://serde.rs/enum-representations.html
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "tag_type", content = "attr")]
-pub enum TagAttrResDto {
-    #[serde(rename = "normal")]
+#[serde(rename_all = "snake_case")]
+pub enum TagAttrDto {
     Normal,
 
-    #[serde(rename = "number")]
-    WithNumber {
-        start: i64,
-        end: i64,
-        defval: i64,
-    },
+    Number { start: i64, end: i64, defval: i64 },
 
-    #[serde(rename = "text")]
-    WithText { defval: String },
+    Text { defval: String },
 
-    #[serde(rename = "date")]
-    WithDate { defval: String },
+    Date { defval: String },
 
-    #[serde(rename = "bool")]
-    WithBool { defval: bool },
+    Bool { defval: bool },
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -50,7 +44,7 @@ pub struct TagResDto {
     pub auth: bool,
 
     #[serde(flatten)]
-    pub attrval: TagAttrResDto,
+    pub attrval: TagAttrDto,
 
     pub created_at: String,
 

--- a/src-tauri/src/modules/tag/domain/error.rs
+++ b/src-tauri/src/modules/tag/domain/error.rs
@@ -61,6 +61,9 @@ pub enum TagGenericError {
     #[error("Invalid date format")]
     InvalidDateFormat(),
 
+    #[error("Invalid number tag value")]
+    InvalidTagNumberValue(),
+
     #[error("unknown Tag error")]
     Unknown{ message: String },
     

--- a/src-tauri/src/modules/tag/domain/factory.rs
+++ b/src-tauri/src/modules/tag/domain/factory.rs
@@ -37,16 +37,16 @@ impl TagFactory {
     pub fn from_plain(object: TagPlainObject) -> Result<Tag, TagGenericError> {
         let attr = match object.attrval {
             TagAttributePlainObject::Normal => TagAttrVO::Normal,
-            TagAttributePlainObject::Number { start, end, defval } => TagAttrVO::WithNumber { start, end, defval },
-            TagAttributePlainObject::Text { defval } => TagAttrVO::WithText { defval },
+            TagAttributePlainObject::Number { start, end, defval } => TagAttrVO::Number { start, end, defval },
+            TagAttributePlainObject::Text { defval } => TagAttrVO::Text { defval },
             TagAttributePlainObject::Date { defval } => {
-                TagAttrVO::WithDate {
+                TagAttrVO::Date {
                     defval: dateutils::parse(defval)
                         .map_err(|_| TagGenericError::InvalidDateFormat())?
                         .and_utc()
                 }
             },
-            TagAttributePlainObject::Bool { defval } => TagAttrVO::WithBool { defval },
+            TagAttributePlainObject::Bool { defval } => TagAttrVO::Bool { defval },
         };
 
         Ok(Tag::new(TagProps {

--- a/src-tauri/src/modules/tag/domain/mod.rs
+++ b/src-tauri/src/modules/tag/domain/mod.rs
@@ -14,8 +14,13 @@ pub use error::TagError;
 pub use error::TagGenericError;
 mod factory;
 pub use factory::TagFactory;
+pub mod valueobj;
 mod plainobj;
 pub use plainobj::TagPlainObject;
+
+use valueobj::TagAttrVO;
+
+use self::plainobj::TagAttributePlainObject;
 
 base_aggregate!(Tag {
     id: TagID,
@@ -24,6 +29,7 @@ base_aggregate!(Tag {
     belong_subject: SubjectID,
     description: String,
     auth: bool,
+    attr: TagAttrVO,
     created_at: DateTime<Utc>,
     updated_at: DateTime<Utc>,
 });
@@ -68,6 +74,14 @@ impl Tag {
 
 impl ToPlainObject<TagPlainObject> for Tag {
     fn to_plain(self) -> TagPlainObject {
+        let attrobj = match self.attr {
+            TagAttrVO::Normal => TagAttributePlainObject::Normal,
+            TagAttrVO::WithNumber { start, end, defval } => TagAttributePlainObject::Number { start, end, defval },
+            TagAttrVO::WithText { defval } => TagAttributePlainObject::Text { defval },
+            TagAttrVO::WithDate { defval } => TagAttributePlainObject::Date { defval: dateutils::format(defval) },
+            TagAttrVO::WithBool { defval } => TagAttributePlainObject::Bool { defval },
+        };
+
         TagPlainObject {
             id: self.id,
             name: self.name,
@@ -76,6 +90,7 @@ impl ToPlainObject<TagPlainObject> for Tag {
             belong_subject: self.belong_subject,
             created_at: dateutils::format(self.created_at),
             updated_at: dateutils::format(self.updated_at),
+            attrval: attrobj,
             auth: self.auth,
         }
     }

--- a/src-tauri/src/modules/tag/domain/mod.rs
+++ b/src-tauri/src/modules/tag/domain/mod.rs
@@ -76,10 +76,10 @@ impl ToPlainObject<TagPlainObject> for Tag {
     fn to_plain(self) -> TagPlainObject {
         let attrobj = match self.attr {
             TagAttrVO::Normal => TagAttributePlainObject::Normal,
-            TagAttrVO::WithNumber { start, end, defval } => TagAttributePlainObject::Number { start, end, defval },
-            TagAttrVO::WithText { defval } => TagAttributePlainObject::Text { defval },
-            TagAttrVO::WithDate { defval } => TagAttributePlainObject::Date { defval: dateutils::format(defval) },
-            TagAttrVO::WithBool { defval } => TagAttributePlainObject::Bool { defval },
+            TagAttrVO::Number { start, end, defval } => TagAttributePlainObject::Number { start, end, defval },
+            TagAttrVO::Text { defval } => TagAttributePlainObject::Text { defval },
+            TagAttrVO::Date { defval } => TagAttributePlainObject::Date { defval: dateutils::format(defval) },
+            TagAttrVO::Bool { defval } => TagAttributePlainObject::Bool { defval },
         };
 
         TagPlainObject {

--- a/src-tauri/src/modules/tag/domain/plainobj.rs
+++ b/src-tauri/src/modules/tag/domain/plainobj.rs
@@ -6,6 +6,26 @@ use crate::modules::subject::domain::SubjectID;
 use super::TagID;
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "tag_type", content = "attr")]
+pub enum TagAttributePlainObject {
+    #[serde(rename = "normal")]
+    Normal,
+
+    #[serde(rename = "number")]
+    Number { start: i64, end: i64, defval: i64 },
+
+    #[serde(rename = "text")]
+    Text { defval: String },
+
+    #[serde(rename = "date")]
+    Date { defval: String },
+
+    #[serde(rename = "bool")]
+    Bool { defval: bool },
+}
+
+
+#[derive(Clone, Serialize, Deserialize)]
 pub struct TagPlainObject {
     pub id: TagID,
 
@@ -22,4 +42,7 @@ pub struct TagPlainObject {
     pub updated_at: String,
 
     pub auth: bool,
+    
+    #[serde(flatten)]
+    pub attrval: TagAttributePlainObject,
 }

--- a/src-tauri/src/modules/tag/domain/plainobj.rs
+++ b/src-tauri/src/modules/tag/domain/plainobj.rs
@@ -7,20 +7,16 @@ use super::TagID;
 
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(tag = "tag_type", content = "attr")]
+#[serde(rename_all = "snake_case")]
 pub enum TagAttributePlainObject {
-    #[serde(rename = "normal")]
     Normal,
 
-    #[serde(rename = "number")]
     Number { start: i64, end: i64, defval: i64 },
 
-    #[serde(rename = "text")]
     Text { defval: String },
 
-    #[serde(rename = "date")]
     Date { defval: String },
 
-    #[serde(rename = "bool")]
     Bool { defval: bool },
 }
 

--- a/src-tauri/src/modules/tag/domain/valueobj/attr.rs
+++ b/src-tauri/src/modules/tag/domain/valueobj/attr.rs
@@ -7,14 +7,14 @@ use crate::modules::tag::domain::TagGenericError;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TagAttrVO {
     Normal,
-    WithNumber {
-        start: i64,
-        end: i64,
-        defval: i64,
-    },
-    WithText { defval: String },
-    WithDate { defval: DateTime<Utc> },
-    WithBool { defval: bool },
+
+    Number { start: i64, end: i64, defval: i64 },
+
+    Text { defval: String },
+
+    Date { defval: DateTime<Utc> },
+
+    Bool { defval: bool },
 }
 
 pub struct TagAttributeFactory { }
@@ -32,22 +32,22 @@ impl TagAttributeFactory {
             return Err(TagGenericError::InvalidTagNumberValue());
         }
 
-        Ok(TagAttrVO::WithNumber{ start, end, defval })
+        Ok(TagAttrVO::Number{ start, end, defval })
     }
 
     pub fn create_text(defval: String) -> Result<TagAttrVO, TagGenericError> {
-        Ok(TagAttrVO::WithText { defval })
+        Ok(TagAttrVO::Text { defval })
     }
 
     pub fn create_date(defval: String) -> Result<TagAttrVO, TagGenericError> {
         if let Ok(date) = dateutils::parse(defval) {
-            return Ok(TagAttrVO::WithDate { defval: date.and_utc() })
+            return Ok(TagAttrVO::Date { defval: date.and_utc() })
         }
 
         Err(TagGenericError::InvalidDateFormat())
     }
 
     pub fn create_bool(defval: bool) -> Result<TagAttrVO, TagGenericError> {
-        Ok(TagAttrVO::WithBool { defval })
+        Ok(TagAttrVO::Bool { defval })
     }
 }

--- a/src-tauri/src/modules/tag/domain/valueobj/attr.rs
+++ b/src-tauri/src/modules/tag/domain/valueobj/attr.rs
@@ -1,0 +1,53 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::modules::common::infrastructure::dateutils;
+use crate::modules::tag::domain::TagGenericError;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TagAttrVO {
+    Normal,
+    WithNumber {
+        start: i64,
+        end: i64,
+        defval: i64,
+    },
+    WithText { defval: String },
+    WithDate { defval: DateTime<Utc> },
+    WithBool { defval: bool },
+}
+
+pub struct TagAttributeFactory { }
+
+impl TagAttributeFactory {
+    pub fn create_normal() -> Result<TagAttrVO, TagGenericError> {
+        Ok(TagAttrVO::Normal)
+    }
+
+    pub fn create_number(start: i64, end: i64, defval: i64) -> Result<TagAttrVO, TagGenericError> {
+        if start > end {
+            return Err(TagGenericError::InvalidTagNumberValue());
+        }
+        if defval < start || defval > end {
+            return Err(TagGenericError::InvalidTagNumberValue());
+        }
+
+        Ok(TagAttrVO::WithNumber{ start, end, defval })
+    }
+
+    pub fn create_text(defval: String) -> Result<TagAttrVO, TagGenericError> {
+        Ok(TagAttrVO::WithText { defval })
+    }
+
+    pub fn create_date(defval: String) -> Result<TagAttrVO, TagGenericError> {
+        if let Ok(date) = dateutils::parse(defval) {
+            return Ok(TagAttrVO::WithDate { defval: date.and_utc() })
+        }
+
+        Err(TagGenericError::InvalidDateFormat())
+    }
+
+    pub fn create_bool(defval: bool) -> Result<TagAttrVO, TagGenericError> {
+        Ok(TagAttrVO::WithBool { defval })
+    }
+}

--- a/src-tauri/src/modules/tag/domain/valueobj/mod.rs
+++ b/src-tauri/src/modules/tag/domain/valueobj/mod.rs
@@ -1,0 +1,2 @@
+mod attr;
+pub use attr::*;

--- a/src-tauri/src/modules/tag/infrastructure/domapper.rs
+++ b/src-tauri/src/modules/tag/infrastructure/domapper.rs
@@ -9,20 +9,20 @@ impl DomainModelMapper<TagAttrVO> for TagAttrDO {
     fn to_domain(self) -> TagAttrVO {
         match self {
             Self::Normal => TagAttrVO::Normal,
-            Self::WithNumber { start, end, defval } => TagAttrVO::WithNumber { start, end, defval },
-            Self::WithText { defval } => TagAttrVO::WithText { defval },
-            Self::WithDate { defval } => TagAttrVO::WithDate { defval: defval.0 },
-            Self::WithBool { defval } => TagAttrVO::WithBool { defval },
+            Self::Number { start, end, defval } => TagAttrVO::Number { start, end, defval },
+            Self::Text { defval } => TagAttrVO::Text { defval },
+            Self::Date { defval } => TagAttrVO::Date { defval: defval.0 },
+            Self::Bool { defval } => TagAttrVO::Bool { defval },
         }
     }
 
     fn from_domain(value: TagAttrVO) -> Self {
         match value {
             TagAttrVO::Normal => Self::Normal,
-            TagAttrVO::WithNumber { start, end, defval } => Self::WithNumber { start, end, defval },
-            TagAttrVO::WithText { defval } => Self::WithText { defval },
-            TagAttrVO::WithDate { defval } => Self::WithDate { defval: Datetime(defval) },
-            TagAttrVO::WithBool { defval } => Self::WithBool { defval },
+            TagAttrVO::Number { start, end, defval } => Self::Number { start, end, defval },
+            TagAttrVO::Text { defval } => Self::Text { defval },
+            TagAttrVO::Date { defval } => Self::Date { defval: Datetime(defval) },
+            TagAttrVO::Bool { defval } => Self::Bool { defval },
         }
     }
 }

--- a/src-tauri/src/modules/tag/infrastructure/domapper.rs
+++ b/src-tauri/src/modules/tag/infrastructure/domapper.rs
@@ -2,7 +2,30 @@ use surrealdb::sql::Datetime;
 
 use crate::modules::common::domain::DomainModelMapper;
 use crate::modules::tag::domain::TagProps;
-use crate::modules::tag::repository::TagDO;
+use crate::modules::tag::domain::valueobj::TagAttrVO;
+use crate::modules::tag::repository::{TagAttrDO, TagDO};
+
+impl DomainModelMapper<TagAttrVO> for TagAttrDO {
+    fn to_domain(self) -> TagAttrVO {
+        match self {
+            Self::Normal => TagAttrVO::Normal,
+            Self::WithNumber { start, end, defval } => TagAttrVO::WithNumber { start, end, defval },
+            Self::WithText { defval } => TagAttrVO::WithText { defval },
+            Self::WithDate { defval } => TagAttrVO::WithDate { defval: defval.0 },
+            Self::WithBool { defval } => TagAttrVO::WithBool { defval },
+        }
+    }
+
+    fn from_domain(value: TagAttrVO) -> Self {
+        match value {
+            TagAttrVO::Normal => Self::Normal,
+            TagAttrVO::WithNumber { start, end, defval } => Self::WithNumber { start, end, defval },
+            TagAttrVO::WithText { defval } => Self::WithText { defval },
+            TagAttrVO::WithDate { defval } => Self::WithDate { defval: Datetime(defval) },
+            TagAttrVO::WithBool { defval } => Self::WithBool { defval },
+        }
+    }
+}
 
 impl DomainModelMapper<TagProps> for TagDO {
     fn to_domain(self) -> TagProps {
@@ -13,6 +36,7 @@ impl DomainModelMapper<TagProps> for TagDO {
             belong_category: self.belong_category.into(),
             belong_subject: self.belong_subject.into(),
             auth: self.auth,
+            attr: self.attrval.to_domain(),
             created_at: self.created_at.0,
             updated_at: self.updated_at.0,
         }
@@ -25,6 +49,7 @@ impl DomainModelMapper<TagProps> for TagDO {
             belong_category: value.belong_category.into(),
             belong_subject: value.belong_subject.into(),
             auth: value.auth,
+            attrval: TagAttrDO::from_domain(value.attr),
             created_at: Datetime(value.created_at),
             updated_at: Datetime(value.updated_at),
         }

--- a/src-tauri/src/modules/tag/repository/data_model.rs
+++ b/src-tauri/src/modules/tag/repository/data_model.rs
@@ -3,25 +3,21 @@ use surrealdb::sql::{Datetime, Thing};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "tag_type", content = "attr")]
+#[serde(rename_all = "snake_case")]
 pub enum TagAttrDO {
-    #[serde(rename = "normal")]
     Normal,
 
-    #[serde(rename = "number")]
-    WithNumber {
+    Number {
         start: i64,
         end: i64,
         defval: i64,
     },
 
-    #[serde(rename = "text")]
-    WithText { defval: String },
+    Text { defval: String },
 
-    #[serde(rename = "date")]
-    WithDate { defval: Datetime },
+    Date { defval: Datetime },
 
-    #[serde(rename = "bool")]
-    WithBool { defval: bool },
+    Bool { defval: bool },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/modules/tag/repository/data_model.rs
+++ b/src-tauri/src/modules/tag/repository/data_model.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+use surrealdb::sql::{Datetime, Thing};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "tag_type", content = "attr")]
+pub enum TagAttrDO {
+    #[serde(rename = "normal")]
+    Normal,
+
+    #[serde(rename = "number")]
+    WithNumber {
+        start: i64,
+        end: i64,
+        defval: i64,
+    },
+
+    #[serde(rename = "text")]
+    WithText { defval: String },
+
+    #[serde(rename = "date")]
+    WithDate { defval: Datetime },
+
+    #[serde(rename = "bool")]
+    WithBool { defval: bool },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TagDO {
+   pub id: Thing,
+
+   pub name: String,
+
+   pub description: String,
+
+   pub auth: bool,
+
+   pub created_at: Datetime,
+
+   pub updated_at: Datetime,
+
+   pub belong_category: Thing, 
+
+   pub belong_subject: Thing,
+
+   #[serde(flatten)]
+   pub attrval: TagAttrDO,
+}

--- a/src-tauri/src/modules/tag/repository/mod.rs
+++ b/src-tauri/src/modules/tag/repository/mod.rs
@@ -4,3 +4,6 @@ pub use query::{TAG_QUERY_REPOSITORY, TagQueryRepository};
 
 mod repository;
 pub use repository::*;
+
+mod data_model;
+pub use data_model::*;

--- a/src-tauri/src/modules/tag/repository/repository.rs
+++ b/src-tauri/src/modules/tag/repository/repository.rs
@@ -1,7 +1,6 @@
 use once_cell::sync::Lazy;
-use serde::{Deserialize, Serialize};
 use surrealdb::Surreal;
-use surrealdb::sql::{Datetime, Thing, thing};
+use surrealdb::sql::{Thing, thing};
 use surrealdb::engine::remote::ws::Client;
 
 use crate::modules::common::domain::DomainModelMapper;
@@ -12,22 +11,9 @@ use crate::modules::common::repository::{CommonRepository, COMMON_REPOSITORY};
 use crate::modules::tag::domain::TagFactory;
 use crate::tag::domain::{Tag, TagID};
 
+use super::TagDO;
+
 pub static TAG_REPOSITORY: TagRepository<'_> = TagRepository::init(&env::DB, &COMMON_REPOSITORY);
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TagDO {
-   pub id: Thing,
-
-   pub name: String,
-   pub description: String,
-   pub auth: bool,
-   pub created_at: Datetime,
-   pub updated_at: Datetime,
-
-   pub belong_category: Thing, 
-
-   pub belong_subject: Thing,
-}
 
 /**
  * Repository */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { ROUTE_OBJECTS } from './router/RoutingTable';
 
 // https://mantine.dev/styles/mantine-styles/#css-layers
 import '@mantine/core/styles.layer.css';
+import '@mantine/dates/styles.layer.css';
 import 'mantine-contextmenu/styles.layer.css';
 
 import '@mantine/dropzone/styles.css';

--- a/src/api/resource/Dto.ts
+++ b/src/api/resource/Dto.ts
@@ -66,6 +66,14 @@ export interface ResourceTagOperateDto {
 
 export type ResourceTagAttrValDto = null | number | string | boolean;
 
+export interface ResourceUpdateTagDto {
+    id: string;
+
+    tag_id: string;
+
+    attrval: ResourceTagAttrValDto,
+}
+
 export type ResourceTagDto = {
     id: string,
 

--- a/src/api/resource/Dto.ts
+++ b/src/api/resource/Dto.ts
@@ -1,3 +1,5 @@
+import { TagAttrValue } from '@api/tag';
+
 export interface ResourceUrlDto {
     full: string;
 
@@ -62,7 +64,9 @@ export interface ResourceTagOperateDto {
     tag_id: string;
 }
 
-export interface ResourceTagDto {
+export type ResourceTagAttrValDto = null | number | string | boolean;
+
+export type ResourceTagDto = {
     id: string,
 
     name: string,
@@ -77,8 +81,12 @@ export interface ResourceTagDto {
 
     created_at: string,
 
+    added_at: string,
+
+    attrval: ResourceTagAttrValDto,
+
     updated_at: string,
-}
+} & TagAttrValue
 
 export interface ResourceDetailDto {
     id: string,

--- a/src/api/resource/ResourceAPI.ts
+++ b/src/api/resource/ResourceAPI.ts
@@ -7,6 +7,7 @@ import {
     ResourceResDto,
     ResourceTagOperateDto,
     ResourceUpdateDto,
+    ResourceUpdateTagDto,
 } from './Dto';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -49,5 +50,9 @@ export namespace ResourceAPI {
 
     export function removeTag(data: ResourceTagOperateDto) {
         return invoke('remove_resource_tag', { data });
+    }
+
+    export function updateTag(data: ResourceUpdateTagDto) {
+        return invoke('update_resource_tag', { data });
     }
 }

--- a/src/api/resource/ResourceMutation.ts
+++ b/src/api/resource/ResourceMutation.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { ResourceAPI } from './ResourceAPI';
-import { ResourceCreateDto, ResourceTagOperateDto, ResourceUpdateDto } from './Dto';
+import { ResourceCreateDto, ResourceTagOperateDto, ResourceUpdateDto, ResourceUpdateTagDto } from './Dto';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace ResourceMutation {
@@ -30,6 +30,12 @@ export namespace ResourceMutation {
 
     export function useRemoveTag() {
         const mutationFn = (data: ResourceTagOperateDto) => ResourceAPI.removeTag(data);
+
+        return useMutation({ mutationFn: mutationFn });
+    }
+
+    export function useUpdateTag() {
+        const mutationFn = (data: ResourceUpdateTagDto) => ResourceAPI.updateTag(data);
 
         return useMutation({ mutationFn: mutationFn });
     }

--- a/src/api/tag/Dto.ts
+++ b/src/api/tag/Dto.ts
@@ -1,4 +1,49 @@
-export interface TagCreateDto {
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace TagAttrPayload {
+    export type Variant = 'normal' | 'number' | 'text' | 'date' | 'bool';
+    export type All =
+        TagAttrPayload.Normal |
+        TagAttrPayload.Number |
+        TagAttrPayload.Text |
+        TagAttrPayload.Date |
+        TagAttrPayload.Bool;
+
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    export type Normal = {};
+    export type Number = { start: number, end: number, defval: number };
+    export type Text = { defval: string };
+    export type Date = { defval: string };
+    export type Bool = { defval: boolean };
+    export type AsType<T extends Variant> =
+        T extends 'normal' ? TagAttrPayload.Normal :
+        T extends 'number' ? TagAttrPayload.Number :
+        T extends 'text' ? TagAttrPayload.Text :
+        T extends 'date' ? TagAttrPayload.Date : TagAttrPayload.Bool;
+
+    export function As<T extends TagAttrPayload.Variant>(attrval: TagAttrPayload.All) {
+        return attrval as TagAttrPayload.AsType<T>;
+    }
+
+    export const DEFAULT_VALUE: {[T in Variant]: AsType<T>} = {
+        normal: {},
+        number: {
+            start:  0,
+            end:    100,
+            defval: 50,
+        },
+        text: { defval: '' },
+        date: { defval: '' },
+        bool: { defval: false },
+    };
+}
+
+export type TagAttrValue = {
+    tag_type: TagAttrPayload.Variant,
+
+    attr: TagAttrPayload.All,
+}
+
+export type TagCreateDto = {
 
     name: string;
 
@@ -7,9 +52,9 @@ export interface TagCreateDto {
     belong_subject: string;
 
     belong_category: string;
-}
+} & TagAttrValue;
 
-export interface TagResDto {
+export type TagResDto = {
     id: string;
 
     name: string;
@@ -29,7 +74,7 @@ export interface TagResDto {
     created_at: string;
 
     updated_at: string;
-}
+} & TagAttrValue;
 
 export interface QueryTagDto {
     id?: string;

--- a/src/api/tag/Dto.ts
+++ b/src/api/tag/Dto.ts
@@ -9,7 +9,7 @@ export namespace TagAttrPayload {
         TagAttrPayload.Bool;
 
     // eslint-disable-next-line @typescript-eslint/ban-types
-    export type Normal = {};
+    export type Normal = null;
     export type Number = { start: number, end: number, defval: number };
     export type Text = { defval: string };
     export type Date = { defval: string };
@@ -25,7 +25,7 @@ export namespace TagAttrPayload {
     }
 
     export const DEFAULT_VALUE: {[T in Variant]: AsType<T>} = {
-        normal: {},
+        normal: null,
         number: {
             start:  0,
             end:    100,

--- a/src/assets/locales/common/en-US.json
+++ b/src/assets/locales/common/en-US.json
@@ -54,5 +54,14 @@
         "PathInput": {
             "file_button": "select local path"
         }
+    },
+    "Value": {
+        "AttributeType": {
+            "normal": "normal",
+            "number": "number",
+            "text": "text",
+            "date": "date",
+            "bool": "bool"
+        }
     }
 }

--- a/src/assets/locales/common/zh-TW.json
+++ b/src/assets/locales/common/zh-TW.json
@@ -54,5 +54,14 @@
         "PathInput": {
             "file_button": "選擇本地路徑"
         }
+    },
+    "Value": {
+        "AttributeType": {
+            "normal": "一般",
+            "number": "數值",
+            "text": "文字",
+            "date": "日期",
+            "bool": "布林"
+        }
     }
 }

--- a/src/assets/locales/modal/create-tag/en-US.json
+++ b/src/assets/locales/modal/create-tag/en-US.json
@@ -1,0 +1,25 @@
+{
+    "Main": {
+        "title": "Create New Tag",
+        "subtitle": "Basic tag data",
+        "belong_subject": "Belong Subject:",
+        "name": "Name:",
+        "name_placeholder": "Enter name here...",
+        "description": "Description:",
+        "description_placeholder": "Enter description here...",
+        "tag_type": "Tag Type:",
+        "cancel": "Cancel",
+        "confirm": "Confirm"
+    },
+    "TagAttributePanelContent": {
+        "title": "Attributes of the {{type}} tag",
+        "default_value": "default value",
+        "date_placehoder": "inpute default date here...",
+        "text_placehoder": "inpute default text here...",
+        "number_range": "number range",
+        "number_start": "start",
+        "number_end": "end",
+        "bool_true": "True",
+        "bool_false": "False"
+    }
+}

--- a/src/assets/locales/modal/create-tag/zh-TW.json
+++ b/src/assets/locales/modal/create-tag/zh-TW.json
@@ -1,0 +1,25 @@
+{
+    "Main": {
+        "title": "建立新的標籤",
+        "subtitle": "基本屬性",
+        "belong_subject": "在此類別下:",
+        "name": "名稱:",
+        "name_placeholder": "在這裡輸入名稱...",
+        "description": "描述:",
+        "description_placeholder": "在這裡輸入描述...",
+        "tag_type": "標籤類型:",
+        "cancel": "取消",
+        "confirm": "確認"
+    },
+    "TagAttributePanelContent": {
+        "title": "{{type}}的標籤屬性",
+        "default_value": "預設值",
+        "date_placehoder": "在這裡預設輸入日期...",
+        "text_placehoder": "在這裡預設文字日期...",
+        "number_range": "範圍",
+        "number_start": "起始",
+        "number_end": "結束",
+        "bool_true": "真",
+        "bool_false": "否"
+    }
+}

--- a/src/components/display/SubTitle.tsx
+++ b/src/components/display/SubTitle.tsx
@@ -1,0 +1,11 @@
+import { ElementProps, Text, TextProps } from '@mantine/core';
+
+export interface SubTitleProps extends TextProps, ElementProps<'div', keyof TextProps> { }
+
+export function SubTitle(props: SubTitleProps) {
+    const { children } = props;
+    return (
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        <Text c="dimmed" fw="bolder" fz="sm" {...props}>{children}</Text>
+    );
+}

--- a/src/components/display/index.ts
+++ b/src/components/display/index.ts
@@ -5,3 +5,4 @@ export * from './EditableText';
 export * from './ResourceThumbnailDisplayer';
 export * from './DateTimeDisplayer';
 export * from './TagTypography';
+export * from './SubTitle';

--- a/src/modals/tag/components/TagAttributePanel.tsx
+++ b/src/modals/tag/components/TagAttributePanel.tsx
@@ -6,6 +6,8 @@ import {
 import { DateInput } from '@mantine/dates';
 import { SubTitle } from '@components/display';
 import { TagAttrPayload, TagCreateDto } from '@api/tag';
+import { useTranslation } from 'react-i18next';
+import { normalizeKey, useValueTranslation } from '@modules/i18next';
 
 export interface TagAttributePanelRootProps extends PropsWithChildren {
     hidden: boolean;
@@ -29,22 +31,23 @@ function TagAttributePanelNumber(props: {
     onDefaultChange: (value: number) => void;
 }) {
     const { value, onStartChange, onEndChange, onDefaultChange } = props;
+    const { t } = useTranslation('modal', { keyPrefix: 'createTag.TagAttributePanelContent' });
 
     const defaultProps: NumberInputProps = {
         w:                '7.5rem',
         size:             'xs',
         stepHoldDelay:    500,
-        stepHoldInterval: (t) => Math.max(1000 / t ** 2, 25),
+        stepHoldInterval: (step) => Math.max(1000 / step ** 2, 25),
     };
 
     return (
         <>
             <Stack gap={5}>
-                <SubTitle>start range</SubTitle>
+                <SubTitle>{t('number_range')}</SubTitle>
                 <Group>
                     <NumberInput
                         {...defaultProps}
-                        label="start"
+                        label={t('number_start')}
                         min={0}
                         max={value.end}
                         defaultValue={0}
@@ -57,7 +60,7 @@ function TagAttributePanelNumber(props: {
                     />
                     <NumberInput
                         {...defaultProps}
-                        label="end"
+                        label={t('number_end')}
                         min={value.start}
                         max={Number.MAX_SAFE_INTEGER}
                         defaultValue={100}
@@ -72,7 +75,7 @@ function TagAttributePanelNumber(props: {
             </Stack>
 
             <Stack gap={5}>
-                <SubTitle>default Value</SubTitle>
+                <SubTitle>{t('default_value')}</SubTitle>
                 <Slider
                     color="blue"
                     min={value.start}
@@ -91,11 +94,13 @@ function TagAttributePanelText(props: {
     onChange(value: string): void;
 }) {
     const { value, onChange } = props;
+    const { t } = useTranslation('modal', { keyPrefix: 'createTag.TagAttributePanelContent' });
+
     return (
         <Stack gap={3}>
-            <SubTitle>Default value</SubTitle>
+            <SubTitle>{t('default_value')}</SubTitle>
             <Input
-                placeholder="input default value..."
+                placeholder={t('text_placehoder')}
                 size="sm"
                 w="100%"
                 value={value.defval}
@@ -111,15 +116,16 @@ function TagAttributePanelBool(props: {
     onChange(value: boolean): void;
 }) {
     const { value, onChange } = props;
+    const { t } = useTranslation('modal', { keyPrefix: 'createTag.TagAttributePanelContent' });
+
     return (
         <Stack gap={3}>
-            <SubTitle>Default value</SubTitle>
+            <SubTitle>{t('default_value')}</SubTitle>
             <Switch
-                placeholder="input default value..."
                 color="lime"
                 size="md"
                 w="100%"
-                label={value.defval ? 'True' : 'False'}
+                label={value.defval ? t('bool_true') : t('bool_false')}
                 checked={value.defval}
                 onChange={(e) => onChange(e.currentTarget.checked)}
             />
@@ -132,6 +138,7 @@ function TagAttributePanelDate(props: {
     onChange(value: string): void;
 }) {
     const { value, onChange } = props;
+    const { t } = useTranslation('modal', { keyPrefix: 'createTag.TagAttributePanelContent' });
 
     function toDate() {
         const date = new Date(value.defval);
@@ -140,13 +147,13 @@ function TagAttributePanelDate(props: {
 
     return (
         <Stack gap={3}>
-            <SubTitle>default value</SubTitle>
+            <SubTitle>{t('default_value')}</SubTitle>
             <DateInput
                 w="100%"
                 value={toDate()}
                 onChange={(val) => val && onChange(val.toISOString())}
                 valueFormat="YYYY/MM/DD"
-                placeholder="Date input"
+                placeholder={t('date_placehoder')}
             />
         </Stack>
     );
@@ -161,6 +168,8 @@ export interface TagAttributePanelContentProps {
 
 function TagAttributePanelContent(props: TagAttributePanelContentProps) {
     const { displayType, onAttributeChange } = props;
+    const { t } = useTranslation('modal', { keyPrefix: 'createTag.TagAttributePanelContent' });
+    const { tv } = useValueTranslation('AttributeType');
     const [attrVal, setAttrVal] = useState<TagAttrPayload.All>({});
 
     // reset
@@ -214,8 +223,7 @@ function TagAttributePanelContent(props: TagAttributePanelContentProps) {
     return (
         <Stack gap={15}>
             <Title order={5}>
-                {displayType.toString()}
-                of Tag Attributes
+                {t('title', { type: tv(normalizeKey(displayType)) })}
             </Title>
             {renderContent()}
         </Stack>

--- a/src/modals/tag/components/TagAttributePanel.tsx
+++ b/src/modals/tag/components/TagAttributePanel.tsx
@@ -1,0 +1,227 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import { PropsWithChildren, useCallback, useEffect, useState } from 'react';
+import {
+    Divider, Group, Input, NumberInput, NumberInputProps, Slider, Stack, Switch, Text, Title,
+} from '@mantine/core';
+import { DateInput } from '@mantine/dates';
+import { SubTitle } from '@components/display';
+import { TagAttrPayload, TagCreateDto } from '@api/tag';
+
+export interface TagAttributePanelRootProps extends PropsWithChildren {
+    hidden: boolean;
+}
+function TagAttributePanelRoot(props: TagAttributePanelRootProps) {
+    const { hidden, children } = props;
+    return (
+        <>
+            {!hidden && <Divider orientation="vertical" />}
+            <Stack display={hidden ? 'none' : 'flex'} w="35%">
+                {children}
+            </Stack>
+        </>
+    );
+}
+
+function TagAttributePanelNumber(props: {
+    value: TagAttrPayload.Number;
+    onStartChange: (value: number) => void;
+    onEndChange: (value: number) => void;
+    onDefaultChange: (value: number) => void;
+}) {
+    const { value, onStartChange, onEndChange, onDefaultChange } = props;
+
+    const defaultProps: NumberInputProps = {
+        w:                '7.5rem',
+        size:             'xs',
+        stepHoldDelay:    500,
+        stepHoldInterval: (t) => Math.max(1000 / t ** 2, 25),
+    };
+
+    return (
+        <>
+            <Stack gap={5}>
+                <SubTitle>start range</SubTitle>
+                <Group>
+                    <NumberInput
+                        {...defaultProps}
+                        label="start"
+                        min={0}
+                        max={value.end}
+                        defaultValue={0}
+                        value={value.start}
+                        onChange={(e) => {
+                            const num = e as number;
+                            onStartChange(num);
+                            onDefaultChange(Math.max(num, value.defval));
+                        }}
+                    />
+                    <NumberInput
+                        {...defaultProps}
+                        label="end"
+                        min={value.start}
+                        max={Number.MAX_SAFE_INTEGER}
+                        defaultValue={100}
+                        value={value.end}
+                        onChange={(e) => {
+                            const num = e as number;
+                            onEndChange(num);
+                            onDefaultChange(Math.min(num, value.defval));
+                        }}
+                    />
+                </Group>
+            </Stack>
+
+            <Stack gap={5}>
+                <SubTitle>default Value</SubTitle>
+                <Slider
+                    color="blue"
+                    min={value.start}
+                    max={value.end}
+                    value={value.defval}
+                    defaultValue={50}
+                    onChange={onDefaultChange}
+                />
+            </Stack>
+        </>
+    );
+}
+// ======================================================================
+function TagAttributePanelText(props: {
+    value: TagAttrPayload.Text;
+    onChange(value: string): void;
+}) {
+    const { value, onChange } = props;
+    return (
+        <Stack gap={3}>
+            <SubTitle>Default value</SubTitle>
+            <Input
+                placeholder="input default value..."
+                size="sm"
+                w="100%"
+                value={value.defval}
+                onChange={(e) => onChange(e.currentTarget.value)}
+            />
+        </Stack>
+    );
+}
+
+// ======================================================================
+function TagAttributePanelBool(props: {
+    value: TagAttrPayload.Bool;
+    onChange(value: boolean): void;
+}) {
+    const { value, onChange } = props;
+    return (
+        <Stack gap={3}>
+            <SubTitle>Default value</SubTitle>
+            <Switch
+                placeholder="input default value..."
+                color="lime"
+                size="md"
+                w="100%"
+                label={value.defval ? 'True' : 'False'}
+                checked={value.defval}
+                onChange={(e) => onChange(e.currentTarget.checked)}
+            />
+        </Stack>
+    );
+}
+// ======================================================================
+function TagAttributePanelDate(props: {
+    value: TagAttrPayload.Date;
+    onChange(value: string): void;
+}) {
+    const { value, onChange } = props;
+
+    function toDate() {
+        const date = new Date(value.defval);
+        return Number.isNaN(date.getTime()) ? null : date;
+    }
+
+    return (
+        <Stack gap={3}>
+            <SubTitle>default value</SubTitle>
+            <DateInput
+                w="100%"
+                value={toDate()}
+                onChange={(val) => val && onChange(val.toISOString())}
+                valueFormat="YYYY/MM/DD"
+                placeholder="Date input"
+            />
+        </Stack>
+    );
+}
+
+// ======================================================================
+export interface TagAttributePanelContentProps {
+    displayType: TagCreateDto['tag_type'];
+
+    onAttributeChange: (value: TagAttrPayload.All) => void;
+}
+
+function TagAttributePanelContent(props: TagAttributePanelContentProps) {
+    const { displayType, onAttributeChange } = props;
+    const [attrVal, setAttrVal] = useState<TagAttrPayload.All>({});
+
+    // reset
+    useEffect(() => setAttrVal(TagAttrPayload.DEFAULT_VALUE[displayType]), [displayType]);
+
+    // emit on change event
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    useEffect(() => onAttributeChange(attrVal), [attrVal]);
+
+    // update attributes
+    const hanldeUpdate = <T extends TagAttrPayload.Variant, F extends keyof TagAttrPayload.AsType<T> = keyof TagAttrPayload.AsType<T>>(
+        fieldName: F,
+        value: TagAttrPayload.AsType<T>[F],
+    ) => {
+        setAttrVal((prev) => ({ ...prev, [fieldName]: value }));
+    };
+
+    const renderContent = useCallback(() => {
+        switch (displayType) {
+        case 'normal': return (<>empty</>);
+        case 'number': return (
+            <TagAttributePanelNumber
+                value={TagAttrPayload.As<'number'>(attrVal)}
+                onStartChange={(val) => hanldeUpdate<'number'>('start', val)}
+                onEndChange={(val) => hanldeUpdate<'number'>('end', val)}
+                onDefaultChange={(val) => hanldeUpdate<'number'>('defval', val)}
+            />
+        );
+        case 'text': return (
+            <TagAttributePanelText
+                value={TagAttrPayload.As<'text'>(attrVal)}
+                onChange={(val) => hanldeUpdate<'text'>('defval', val)}
+            />
+        );
+        case 'date': return (
+            <TagAttributePanelDate
+                value={TagAttrPayload.As<'date'>(attrVal)}
+                onChange={(val) => hanldeUpdate<'date'>('defval', val)}
+            />
+        );
+        case 'bool': return (
+            <TagAttributePanelBool
+                value={TagAttrPayload.As<'bool'>(attrVal)}
+                onChange={(val) => hanldeUpdate<'bool'>('defval', val)}
+            />
+        );
+        default: return <Text>Needed implments</Text>;
+        }
+    }, [attrVal, displayType]);
+
+    return (
+        <Stack gap={15}>
+            <Title order={5}>
+                {displayType.toString()}
+                of Tag Attributes
+            </Title>
+            {renderContent()}
+        </Stack>
+    );
+}
+
+export function TagAttributePanel() {}
+TagAttributePanel.Root = TagAttributePanelRoot;
+TagAttributePanel.Content = TagAttributePanelContent;

--- a/src/modals/tag/components/TagAttributePanel.tsx
+++ b/src/modals/tag/components/TagAttributePanel.tsx
@@ -170,7 +170,7 @@ function TagAttributePanelContent(props: TagAttributePanelContentProps) {
     const { displayType, onAttributeChange } = props;
     const { t } = useTranslation('modal', { keyPrefix: 'createTag.TagAttributePanelContent' });
     const { tv } = useValueTranslation('AttributeType');
-    const [attrVal, setAttrVal] = useState<TagAttrPayload.All>({});
+    const [attrVal, setAttrVal] = useState<TagAttrPayload.All>(null);
 
     // reset
     useEffect(() => setAttrVal(TagAttrPayload.DEFAULT_VALUE[displayType]), [displayType]);
@@ -184,10 +184,13 @@ function TagAttributePanelContent(props: TagAttributePanelContentProps) {
         fieldName: F,
         value: TagAttrPayload.AsType<T>[F],
     ) => {
-        setAttrVal((prev) => ({ ...prev, [fieldName]: value }));
+        setAttrVal((prev) => prev && ({ ...prev, [fieldName]: value }));
     };
 
     const renderContent = useCallback(() => {
+        if (!attrVal) {
+            return;
+        }
         switch (displayType) {
         case 'normal': return (<>empty</>);
         case 'number': return (

--- a/src/modals/tag/components/index.ts
+++ b/src/modals/tag/components/index.ts
@@ -1,0 +1,1 @@
+export * from './TagAttributePanel';

--- a/src/modals/tag/createTagModal.tsx
+++ b/src/modals/tag/createTagModal.tsx
@@ -9,6 +9,8 @@ import { SubjectQuery } from '@api/subject';
 import { ErrorResBody } from '@api/common';
 import { showNotification } from '@components/notification';
 import { BaseModal } from '@components/modal';
+import { useTranslation } from 'react-i18next';
+import { normalizeKey, useValueTranslation } from '@modules/i18next';
 import { TagAttributePanel } from './components';
 
 const DEFAULT_VALUE: TagCreateDto = {
@@ -21,6 +23,8 @@ const DEFAULT_VALUE: TagCreateDto = {
 };
 
 export function CreateTagModal() {
+    const { t } = useTranslation('modal', { keyPrefix: 'createTag.Main' });
+    const { tv } = useValueTranslation('AttributeType');
     const { activeCategory } = useActiveCategoryRedux();
     const [opened, { close, confirmClose, cancelClose }] = useCreateTagModal();
     const { data: subjectData } = SubjectQuery.useGetByCategory(activeCategory && activeCategory.id);
@@ -57,12 +61,12 @@ export function CreateTagModal() {
         return null;
     }
     return (
-        <BaseModal opened={opened} onClose={close} title="Create New Tag" size="xl">
+        <BaseModal opened={opened} onClose={close} title={t('title')} size="xl">
             <Group wrap="nowrap" align="stretch">
                 <Stack flex={1} gap={15}>
-                    <Title order={5}>Basic tag data</Title>
+                    <Title order={5}>{t('subtitle')}</Title>
                     <Stack gap={3}>
-                        <SubTitle>Belong Subject:</SubTitle>
+                        <SubTitle>{t('belong_subject')}</SubTitle>
                         <SubjectSelect
                             value={belongSubject?.value}
                             onClickResult={() => setBelongSubject(null)}
@@ -72,25 +76,25 @@ export function CreateTagModal() {
                     </Stack>
 
                     <Stack gap={3}>
-                        <SubTitle>Name:</SubTitle>
+                        <SubTitle>{t('name')}</SubTitle>
                         <Input
-                            placeholder="resource name"
+                            placeholder={t('name_placeholder')}
                             value={data.name}
                             onChange={(e) => handleUpdateData('name', e.target.value)}
                         />
                     </Stack>
 
                     <Stack gap={3}>
-                        <SubTitle>Description:</SubTitle>
+                        <SubTitle>{t('description')}</SubTitle>
                         <Input
-                            placeholder="resource description"
+                            placeholder={t('description_placeholder')}
                             value={data.description}
                             onChange={(e) => handleUpdateData('description', e.target.value)}
                         />
                     </Stack>
 
                     <Stack gap={3}>
-                        <SubTitle>Tag Type:</SubTitle>
+                        <SubTitle>{t('tag_type')}</SubTitle>
                         <SegmentedControl
                             color="blue"
                             defaultValue="normal"
@@ -98,13 +102,16 @@ export function CreateTagModal() {
                             miw="20rem"
                             value={data.tag_type}
                             onChange={(value) => handleUpdateData('tag_type', value as TagCreateDto['tag_type'])}
-                            data={Object.keys(TagAttrPayload.DEFAULT_VALUE)}
+                            data={
+                                Object.keys(TagAttrPayload.DEFAULT_VALUE)
+                                    .map((val) => ({ value: val, label: tv(normalizeKey(val)) }))
+                            }
                         />
                     </Stack>
 
                     <Group justify="space-between">
-                        <Button color="pink" onClick={cancelClose}>Cancel</Button>
-                        <Button color="lime" onClick={handleCreateConfirm}>Confirm</Button>
+                        <Button color="pink" onClick={cancelClose}>{t('cancel')}</Button>
+                        <Button color="lime" onClick={handleCreateConfirm}>{t('confirm')}</Button>
                     </Group>
                 </Stack>
 

--- a/src/modals/tag/createTagModal.tsx
+++ b/src/modals/tag/createTagModal.tsx
@@ -19,7 +19,7 @@ const DEFAULT_VALUE: TagCreateDto = {
     belong_category: '',
     belong_subject:  '',
     tag_type:        'normal',
-    attr:            {},
+    attr:            null,
 };
 
 export function CreateTagModal() {

--- a/src/modules/i18next/hooks.ts
+++ b/src/modules/i18next/hooks.ts
@@ -1,0 +1,8 @@
+import { TFunction, _Resources } from 'i18next';
+import { useTranslation } from 'react-i18next';
+
+export function useValueTranslation<T extends keyof _Resources['common']['Value']>(key: T) {
+    const { t, ...funcs } = useTranslation('common', { keyPrefix: `Value.${key}` });
+    const tv = t as TFunction<'common', `Value.${T}`>;
+    return { tv, ...funcs };
+}

--- a/src/modules/i18next/i18next.ts
+++ b/src/modules/i18next/i18next.ts
@@ -9,12 +9,14 @@ import pageCommonEN_US from '@assets/locales/pages/common/en-US.json';
 import pageCategorylistEN_US from '@assets/locales/pages/category-list/en-US.json';
 import pageResourcelistEN_US from '@assets/locales/pages/resource-list/en-US.json';
 import pageResourceAddEN_US from '@assets/locales/pages/resource-add/en-US.json';
+import modalTagCreateEN_US from '@assets/locales/modal/create-tag/en-US.json';
 
 import commonZH_TW from '@assets/locales/common/zh-TW.json';
 import pageCommonZH_TW from '@assets/locales/pages/common/zh-TW.json';
 import pageCategorylistZH_TW from '@assets/locales/pages/category-list/zh-TW.json';
 import pageResourcelistZH_TW from '@assets/locales/pages/resource-list/zh-TW.json';
 import pageResourceAddZH_TW from '@assets/locales/pages/resource-add/zh-TW.json';
+import modalTagCreateZH_TW from '@assets/locales/modal/create-tag/zh-TW.json';
 
 export type SupportLangsType = 'enUS' | 'zhTW';
 
@@ -42,6 +44,7 @@ export const resources = {
             resourceList: pageResourcelistEN_US,
             resourceAdd:  pageResourceAddEN_US,
         },
+        modal: { createTag: modalTagCreateEN_US },
     },
     [SupportLangs.zhTW.key]: {
         common: commonZH_TW,
@@ -51,6 +54,7 @@ export const resources = {
             resourceList: pageResourcelistZH_TW,
             resourceAdd:  pageResourceAddZH_TW,
         },
+        modal: { createTag: modalTagCreateZH_TW },
     },
 } as const;
 

--- a/src/modules/i18next/index.ts
+++ b/src/modules/i18next/index.ts
@@ -1,1 +1,2 @@
 export * from './i18next';
+export * from './hooks';

--- a/src/pages/resource-detail/ResourceDetailPage.tsx
+++ b/src/pages/resource-detail/ResourceDetailPage.tsx
@@ -30,6 +30,7 @@ export default function ResourcesDetailPage() {
     const exporeFile = ResourceMutation.useExporeFile();
     const addResourceTag = ResourceMutation.useAddTag();
     const removeResourceTag = ResourceMutation.useRemoveTag();
+    const updateResourceTag = ResourceMutation.useUpdateTag();
 
     const {
         data: resourceData,
@@ -119,8 +120,16 @@ export default function ResourcesDetailPage() {
                                         await addResourceTag.mutateAsync({ id: resourceData.id, tag_id: tag.id });
                                         resourceRefetch();
                                     }}
-                                    onRemoveExistTag={async (tag) => {
+                                    onRemoveTag={async (tag) => {
                                         await removeResourceTag.mutateAsync({ id: resourceData.id, tag_id: tag.id });
+                                        resourceRefetch();
+                                    }}
+                                    onUpdateTag={async (tag, attrVal) => {
+                                        await updateResourceTag.mutateAsync({
+                                            id:      resourceData.id,
+                                            tag_id:  tag.id,
+                                            attrval: attrVal,
+                                        });
                                         resourceRefetch();
                                     }}
                                 />

--- a/src/pages/resource-detail/components/ResourceTagPill.module.scss
+++ b/src/pages/resource-detail/components/ResourceTagPill.module.scss
@@ -1,9 +1,9 @@
-.pillRoot {
+.root {
     border: var(--mantine-color-gray-4) solid 1px;
     flex: unset;
     display: flex;
 }
 
-.pilllabel {
+.label {
     margin-bottom: 3px
 }

--- a/src/pages/resource-detail/components/ResourceTagPill.tsx
+++ b/src/pages/resource-detail/components/ResourceTagPill.tsx
@@ -1,0 +1,41 @@
+import { ResourceTagAttrValDto, ResourceTagDto } from '@api/resource';
+import { EditableText } from '@components/display';
+import { Group, Pill, Text } from '@mantine/core';
+import millify from 'millify';
+
+import classes from './ResourceTagPill.module.scss';
+
+export interface ResourceTagPillProps {
+    tag: ResourceTagDto
+
+    onRemoveTag: (tag: Pick<ResourceTagDto, 'id'|'name'>) => void;
+
+    onUpdateTag: (tag: Pick<ResourceTagDto, 'id'|'name'>, value: ResourceTagAttrValDto) => void;
+}
+
+export function ResourceTagPill(props: ResourceTagPillProps) {
+    const { tag, onRemoveTag, onUpdateTag } = props;
+
+    return (
+        <Pill
+            classNames={classes}
+            withRemoveButton
+            key={tag.id}
+            onRemove={() => onRemoveTag({ id: tag.id, name: tag.name })}
+        >
+            <Group gap={3} align="baseline">
+                {tag.name}
+                {tag.attrval !== null && (
+                    <Group gap={0} align="baseline">
+                        <Text c="teal" fz="0.8rem">[</Text>
+                        <EditableText c="teal" fz="0.8rem" value={tag.attrval?.toString()} name="attr" onChange={(val) => onUpdateTag({ id: tag.id, name: tag.name }, val)} />
+                        <Text c="teal" fz="0.8rem">]</Text>
+                    </Group>
+                )}
+                <Text size="xs" opacity="0.6" component="span">
+                    {`(${millify(tag.tagged_count)})`}
+                </Text>
+            </Group>
+        </Pill>
+    );
+}

--- a/src/pages/resource-detail/components/ResourceTagStack.tsx
+++ b/src/pages/resource-detail/components/ResourceTagStack.tsx
@@ -1,12 +1,11 @@
 import { PropsWithChildren, useState, useMemo, useRef, useEffect } from 'react';
-import { Flex, Group, Pill, Stack, Text } from '@mantine/core';
-import { millify } from 'millify';
-import { ResourceTagDto } from '@api/resource';
+import { Flex, Group, Stack, Text } from '@mantine/core';
+import { ResourceTagAttrValDto, ResourceTagDto } from '@api/resource';
 import { TagQuery, TagResDto } from '@api/tag';
 
 import { ResourceTagSelect } from './ResourceTagSelect';
 
-import classes from './ResourceTagStack.module.scss';
+import { ResourceTagPill } from './ResourceTagPill';
 
 export interface ResourceTagGroupProps {
     subjectName: string;
@@ -19,11 +18,13 @@ export interface ResourceTagGroupProps {
 
     onSelectNewTag: (tag: Pick<ResourceTagDto, 'id'|'name'>) => void;
 
-    onRemoveExistTag: (tag: Pick<ResourceTagDto, 'id'|'name'>) => void;
+    onRemoveTag: (tag: Pick<ResourceTagDto, 'id'|'name'>) => void;
+
+    onUpdateTag: (tag: Pick<ResourceTagDto, 'id'|'name'>, attrVal: ResourceTagAttrValDto) => void;
 }
 
 export function ResourceTagGroup(props: ResourceTagGroupProps) {
-    const { subjectName, autoFocus, subjectId, tags, onSelectNewTag, onRemoveExistTag } = props;
+    const { subjectName, autoFocus, subjectId, tags, onSelectNewTag, onRemoveTag, onUpdateTag } = props;
     const selectRef = useRef<HTMLInputElement>(null);
     const [searchValue, setSearchValue] = useState<string>('');
     const [selectValue, setSelectValue] = useState<string>('');
@@ -47,20 +48,7 @@ export function ResourceTagGroup(props: ResourceTagGroupProps) {
         }
     };
 
-    const itemChip = tags.map((val) => (
-        <Pill
-            classNames={{ root: classes.pillRoot, label: classes.pilllabel }}
-            withRemoveButton
-            key={val.id}
-            onRemove={() => onRemoveExistTag({ id: val.id, name: val.name })}
-        >
-            {val.name}
-            <Text size="0.5rem" component="span" c="teal">{val.attrval?.toString()}</Text>
-            <Text size="xs" opacity="0.6" pl={5} component="span">
-                {`(${millify(val.tagged_count)})`}
-            </Text>
-        </Pill>
-    ));
+    const itemChip = tags.map((val) => <ResourceTagPill key={val.id} tag={val} onRemoveTag={onRemoveTag} onUpdateTag={onUpdateTag} />);
 
     const selectableTags = useMemo(() => subjectTags
         .filter((tag) => !tags.find((obj) => obj.id === tag.id)), [tags, subjectTags]);

--- a/src/pages/resource-detail/components/ResourceTagStack.tsx
+++ b/src/pages/resource-detail/components/ResourceTagStack.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, useState, useMemo, useRef, useEffect } from 'react';
 import { Flex, Group, Pill, Stack, Text } from '@mantine/core';
-import { millify }  from 'millify';
+import { millify } from 'millify';
 import { ResourceTagDto } from '@api/resource';
 import { TagQuery, TagResDto } from '@api/tag';
 
@@ -55,6 +55,7 @@ export function ResourceTagGroup(props: ResourceTagGroupProps) {
             onRemove={() => onRemoveExistTag({ id: val.id, name: val.name })}
         >
             {val.name}
+            <Text size="0.5rem" component="span" c="teal">{val.attrval?.toString()}</Text>
             <Text size="xs" opacity="0.6" pl={5} component="span">
                 {`(${millify(val.tagged_count)})`}
             </Text>


### PR DESCRIPTION
# Description
添加 Tag Attribute 屬性 \
提供更強大且多用途的標籤

## 主要的改動
### 標籤種類的延伸
這次種共新的了 5 種標籤種類
- normal
   > 就是不帶任何資料的一般標籤
- number
   > 有`起始值(start)` 跟 `結束值(end)` 以及 `預設值(default)` 的`正整數`資料的標籤
- text
  > 包含`任何文字`的標籤
- date
  > 包含`日期`的標籤
- bool
  > 只包含`True`與`False`的標籤

### 搜尋方法
這些種類的標籤搜尋方法跟 \
[Feature: functional advance search](https://github.com/Bill2015/maku-everything/issues/10) \
一樣，透過 `{}` 來表示內容
- normal
   > 不能包含 `{}`
   > example:  **+"Animal:Cat"**
- number
   > 可以是`單一值或範圍`
   > example:  **+"Misc:Rating"{5}**,   **+"Misc:Rating"{1..5}**
- text
  > 可以包含`任何文字`
   > example: **+"Misc:Color{red}"**
- date
  > 可以是`單一日期或範圍`
  > example:  **+"Other:Publish"{2020/01/01}**,   **+"Other:Publish"{2020/01/01..2021/01/01}**
- bool
  > 只能包含`True`與`False`或 `0` 與 `1`
  > example:  **+"Other:Visited"{true}**,   **+"Other:Visited"{0}**

### 編輯方法
目前所有的編輯方法都是透過連續點及兩下的 tag pill 來立即修改
未來會為所有的種類添加各自的修改方法

# Related Issues
- [Feature: add advanced tag system](https://github.com/Bill2015/maku-everything/issues/17)
- [Feature: functional advance search](https://github.com/Bill2015/maku-everything/issues/10)