### PR TITLE
Chore: replace lodash with Remeda

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -31,7 +31,6 @@ module.exports = {
         // SVG Mock
         '\\.(svg)$': '<rootDir>/src/__test__/mocks/svgMock.tsx',
         '\\.(css|less|scss)$': '<rootDir>/src/__test__/mocks/styleMock.js',
-        // '^lodash-es$': 'lodash',
         ...pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>' }),
     },
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
 				"embla-carousel-react": "^7.1.0",
 				"i18next": "^23.9.0",
 				"immer": "^10.0.3",
-				"lodash": "^4.17.21",
 				"mantine-contextmenu": "^7.5.0",
 				"millify": "^6.1.0",
 				"react": "^18.2.0",
@@ -32,6 +31,7 @@
 				"react-icons": "^5.0.1",
 				"react-redux": "^9.1.0",
 				"react-router-dom": "^6.22.1",
+				"remeda": "^1.43.0",
 				"zustand": "^4.5.1"
 			},
 			"devDependencies": {
@@ -9444,7 +9444,8 @@
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true
 		},
 		"node_modules/lodash.memoize": {
 			"version": "4.1.2",
@@ -10896,6 +10897,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/remeda": {
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/remeda/-/remeda-1.43.0.tgz",
+			"integrity": "sha512-YMGznJxotoGxoWH15H5v0DtceM+rKsGSO43+qULtPlFJSJ87ZWOHC1JP4iXQmVO9ZT5JFT0SPZQaZUpn4FXJbw=="
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
 		"embla-carousel-react": "^7.1.0",
 		"i18next": "^23.9.0",
 		"immer": "^10.0.3",
-		"lodash": "^4.17.21",
 		"mantine-contextmenu": "^7.5.0",
 		"millify": "^6.1.0",
 		"react": "^18.2.0",
@@ -37,6 +36,7 @@
 		"react-icons": "^5.0.1",
 		"react-redux": "^9.1.0",
 		"react-router-dom": "^6.22.1",
+		"remeda": "^1.43.0",
 		"zustand": "^4.5.1"
 	},
 	"devDependencies": {

--- a/src/components/display/ResponsiveImage.tsx
+++ b/src/components/display/ResponsiveImage.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import lodash from 'lodash';
 import { Image, ImageProps, Loader } from '@mantine/core';
 import { useState } from 'react';
 
@@ -26,7 +25,7 @@ export function ResponsiveImage(props: ResponsiveImageProps) {
                     w="100%"
                     display="flex"
                     size="lg"
-                    h={lodash.random(100, 300)}
+                    h={(Math.random() * 300) + 100}
                     style={{ alignItems: 'center', justifyContent: 'center' }}
                 />
             ) }

--- a/src/components/input/ComplexSearch/hooks.ts
+++ b/src/components/input/ComplexSearch/hooks.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
-import lodash from 'lodash';
+import * as R from 'remeda';
 import { TagResDto } from '@api/tag';
 
 import { QueryingNodeProps } from './QueryingNode';
@@ -250,13 +250,13 @@ export const useComplexSearch = (tags: TagResDto[], searchText: string) => {
             };
             let concatNode: QueryingNodeProps | null = null;
             if (!comboxProps) {
-                newNode = lodash.merge<QueryingNodeProps, QueryingNodeProps>(newNode, { type: 'attribute', label: value });
+                newNode = R.merge<QueryingNodeProps, QueryingNodeProps>(newNode, { type: 'attribute', label: value });
             }
             else if (InputSymbol.isValid(value)) {
-                newNode = lodash.merge<QueryingNodeProps, QueryingNodeProps>(newNode, { type: 'operator', label: value });
+                newNode = R.merge<QueryingNodeProps, QueryingNodeProps>(newNode, { type: 'operator', label: value });
             }
             else {
-                newNode = lodash.merge<QueryingNodeProps, QueryingNodeProps>(newNode, {
+                newNode = R.merge<QueryingNodeProps, QueryingNodeProps>(newNode, {
                     type: 'tag', label: comboxProps['data-name']!, groupName: comboxProps['data-groupname']!,
                 });
                 concatNode = { type: 'display-only', label: (status.groupStatus === 'in-include') ? 'or' : 'and' };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,10 @@ import react from '@vitejs/plugin-react';
 export default defineConfig(async () => ({
     plugins: [
         react(),
-        visualizer() as PluginOption,
+        visualizer({
+            emitFile: true,
+            filename: "build-size-report.html",
+        }) as PluginOption,
     ],
     css: {
         preprocessorOptions: {


### PR DESCRIPTION
## Description

Because the lodash are too large when built, also the tree-shaking is not supported! need to use lodash-es to achieve that. Also, jest settings are not friendly too. need to put more effort into setting up the lodash mapping.