### PR TITLE
Add feature that can rename the file from resource page

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -87,6 +87,7 @@ fn main() {
             resource::application::add_resource_tag,
             resource::application::remove_resource_tag,
             resource::application::update_resource_tag,
+            resource::application::rename_resource_file_name,
             resource::application::get_resource_detail,
             resource::application::list_resource,
             resource::application::querying_by_string,

--- a/src-tauri/src/modules/resource/application/command/mod.rs
+++ b/src-tauri/src/modules/resource/application/command/mod.rs
@@ -12,3 +12,6 @@ pub use resource_remove_tag::*;
 
 mod resource_update_tag;
 pub use resource_update_tag::*;
+
+mod rename_file;
+pub use rename_file::*;

--- a/src-tauri/src/modules/resource/application/command/rename_file/dto.rs
+++ b/src-tauri/src/modules/resource/application/command/rename_file/dto.rs
@@ -1,0 +1,8 @@
+use serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct ResourceRenameFileDto {
+    pub id: String,
+
+    pub new_name: Option<String>,
+}

--- a/src-tauri/src/modules/resource/application/command/rename_file/mod.rs
+++ b/src-tauri/src/modules/resource/application/command/rename_file/mod.rs
@@ -1,0 +1,67 @@
+use anyhow::Error;
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::command_from_dto;
+use crate::modules::resource::domain::{ResourceGenericError, ResourceID};
+use crate::modules::resource::repository::ResourceRepository;
+use crate::modules::common::application::ICommandHandler;
+
+mod dto;
+pub use dto::*;
+
+#[derive(Deserialize)]
+pub struct ResourceRenameFileCommand {
+    pub id: String,
+
+    pub new_name: Option<String>,
+}
+command_from_dto!(ResourceRenameFileCommand, ResourceRenameFileDto);
+
+// =====================================
+pub struct ResourceRenameFileHandler<'a> {
+    resource_repo: &'a ResourceRepository<'a>,
+}
+
+impl<'a> ResourceRenameFileHandler<'a> {
+    pub fn register(resource_repo: &'a ResourceRepository) -> Self {
+        Self { resource_repo }
+    }
+}
+
+#[async_trait]
+impl ICommandHandler<ResourceRenameFileCommand> for ResourceRenameFileHandler<'_> {
+
+    fn get_name() -> String {
+        String::from("Create Resource Command")
+    }
+
+    type Output = ResourceID;
+
+    async fn execute(&self, command: ResourceRenameFileCommand) -> Result<Self::Output, Error> {
+        let ResourceRenameFileCommand { 
+            id,
+            new_name,
+        } = command;
+
+        // find by id
+        let mut resource = self.resource_repo
+            .find_by_id(id)
+            .await
+            .or(Err(ResourceGenericError::DBInternalError()))?
+            .ok_or(ResourceGenericError::IdNotFound())?;
+
+        // rename the file
+        resource.rename_file(new_name)?;
+        
+        // save
+        let result = self.resource_repo
+            .save(resource)
+            .await;
+        
+        match result {
+            Ok(value) => Ok(value.take_id()),
+            _ => Err(ResourceGenericError::DBInternalError().into()),
+        }
+    }
+}

--- a/src-tauri/src/modules/resource/application/dto/request.rs
+++ b/src-tauri/src/modules/resource/application/dto/request.rs
@@ -22,3 +22,8 @@ impl Into<TaggingAttrPayload> for ResourceTaggingAttrPayloadDto {
         }
     }
 }
+
+#[derive(Serialize, Deserialize)]
+pub struct ResourceIdOnlyDto {
+    id: String,
+}

--- a/src-tauri/src/modules/resource/application/dto/response.rs
+++ b/src-tauri/src/modules/resource/application/dto/response.rs
@@ -18,7 +18,7 @@ pub struct ResourceFileDto {
 
     pub path: String,
 
-    pub ext: String,
+    pub ext: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src-tauri/src/modules/resource/application/service.rs
+++ b/src-tauri/src/modules/resource/application/service.rs
@@ -57,6 +57,17 @@ impl<'a> ResourceService<'a> {
         Ok(result)
     }
 
+    pub async fn rename_file(&self, data: ResourceRenameFileDto) -> Result<ResourceID, ResourceError> {
+        let command = ResourceRenameFileCommand::from(data);
+
+        let result = ResourceRenameFileHandler::register(self.resource_repository)
+            .execute(command)
+            .await
+            .map_err(|err| ResourceError::Rename(anyhow!(err)))?;
+
+        Ok(result)
+    }
+
     pub async fn update_resource(&self, data: UpdateResourceDto) -> Result<ResourceID, ResourceError> {
         let command = UpdateResourceCommand::from(data);
 

--- a/src-tauri/src/modules/resource/application/tauri-command.rs
+++ b/src-tauri/src/modules/resource/application/tauri-command.rs
@@ -43,6 +43,15 @@ pub async fn remove_resource_tag(data: ResourceRemoveTagDto) -> Result<ResourceI
 }
 
 #[tauri::command(rename_all = "snake_case")]
+pub async fn rename_resource_file_name(data: ResourceRenameFileDto) -> Result<ResourceID, ResourceError> {
+    let result = RESOURCE_SERVICE
+        .rename_file(data)
+        .await?;
+
+    Ok(result)
+}
+
+#[tauri::command(rename_all = "snake_case")]
 pub async fn update_resource_tag(data: ResourceUpdateTagDto) -> Result<ResourceID, ResourceError> {
     let result = RESOURCE_SERVICE
         .update_resource_tag(data)

--- a/src-tauri/src/modules/resource/domain/error.rs
+++ b/src-tauri/src/modules/resource/domain/error.rs
@@ -38,6 +38,9 @@ pub enum ResourceError {
 
     #[error("Explore file failed")]
     ExploreFile(Error),
+
+    #[error("Rename file failed")]
+    Rename(Error),
 }
 
 impl Serialize for ResourceError {
@@ -57,6 +60,7 @@ impl Serialize for ResourceError {
             ResourceError::RemoveTag(source) => serialize_error!(self, source),
             ResourceError::UpdateTag(source) => serialize_error!(self, source),
             ResourceError::ExploreFile(source) => serialize_error!(self, source),
+            ResourceError::Rename(source) => serialize_error!(self, source),
         };
         error_message.serialize(serializer)
     }
@@ -79,6 +83,9 @@ pub enum ResourceGenericError {
     #[error("No File name")]
     FileNameIsEmpty(),
     
+    #[error("Rename file failed")]
+    RenameFileFailed(),
+
     #[error("Name is empty")]
     NameIsEmpty(),
 
@@ -96,6 +103,9 @@ pub enum ResourceGenericError {
 
     #[error("Id not found")]
     IdNotFound(),
+
+    #[error("File Is Empty")]
+    FileIsEmpty(),
 
     #[error("Belong Category id is not exists")]
     BelongCategoryNotExists(),

--- a/src-tauri/src/modules/resource/domain/mod.rs
+++ b/src-tauri/src/modules/resource/domain/mod.rs
@@ -70,17 +70,16 @@ impl Resource {
         }
 
         let file_path = String::from(Path::new(&path).file_name().unwrap().to_str().unwrap());
-        let new_path = vec![
-                Path::new(path.slice(..path.chars().count() - file_path.chars().count()))
-                    .join(&new_name)
-                    .to_str()
-                    .unwrap(), 
-                &ext,
-            ]
-            .into_iter()
-            .filter(|v| !v.is_empty())
-            .collect::<Vec<&str>>()
-            .join(".");
+        let new_path = Path::new(path.slice(..path.chars().count() - file_path.chars().count()))
+            .join(&new_name)
+            .to_str()
+            .unwrap()
+            .to_string();
+    
+        let new_path: String = match &ext {
+            Some(ex) => [new_path, ex.to_string()].join("."),
+            None => new_path,
+        };
 
         // check filename is already exist (conflict)
         if Path::new(&self.root_path).join(&new_path).exists() {

--- a/src-tauri/src/modules/resource/domain/mod.rs
+++ b/src-tauri/src/modules/resource/domain/mod.rs
@@ -1,9 +1,13 @@
+use std::fs;
+use std::path::Path;
+
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use crate::base_aggregate;
 use crate::modules::category::domain::CategoryID;
 use crate::modules::common::domain::ToPlainObject;
 use crate::modules::common::infrastructure::dateutils;
+use crate::utils::StringUtils;
 
 mod id;
 pub use id::ResourceID;
@@ -48,6 +52,55 @@ impl Resource {
             return Err(ResourceGenericError::NameIsEmpty());
         }
         self.name = new_name;
+        Ok(())
+    }
+
+    pub fn rename_file(&mut self, new_name: Option<String>) -> Result<(), ResourceGenericError> {
+        if self.file.is_none() {
+            return Err(ResourceGenericError::FileIsEmpty());
+        }
+
+        // get new name
+        let new_name = new_name.unwrap_or(self.name.clone());
+        let ResourceFileVO { uuid, name, path, ext } = self.file.to_owned().unwrap();
+    
+        // if same as new, do nothing
+        if name == new_name {
+            return Ok(());
+        }
+
+        let file_path = String::from(Path::new(&path).file_name().unwrap().to_str().unwrap());
+        let new_path = vec![
+                Path::new(path.slice(..path.chars().count() - file_path.chars().count()))
+                    .join(&new_name)
+                    .to_str()
+                    .unwrap(), 
+                &ext,
+            ]
+            .into_iter()
+            .filter(|v| !v.is_empty())
+            .collect::<Vec<&str>>()
+            .join(".");
+
+        // check filename is already exist (conflict)
+        if Path::new(&self.root_path).join(&new_path).exists() {
+            return Err(ResourceGenericError::RenameFileFailed());
+        }
+
+        fs::rename(
+            Path::new(&self.root_path).join(&path),
+            Path::new(&self.root_path).join(&new_path)
+        ).or(Err(ResourceGenericError::RenameFileFailed()))?;
+
+        self.file = Some(ResourceFileVO {
+            name: new_name.clone(),
+            path: new_path,
+            uuid: uuid,
+            ext: ext,
+        });
+
+        self.name = new_name;
+
         Ok(())
     }
 

--- a/src-tauri/src/modules/resource/domain/valueobj/filevo.rs
+++ b/src-tauri/src/modules/resource/domain/valueobj/filevo.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use serde::Serialize;
 
 use crate::modules::resource::domain::ResourceGenericError;
+use crate::utils::StringUtils;
 
 #[derive(Debug, Serialize, Clone)]
 pub struct ResourceFileVO {
@@ -32,15 +33,23 @@ impl ResourceFileVO {
         }
 
         let ext = match path.is_file() {
-            true => path.extension().unwrap_or(OsStr::new("txt")),
+            true => path.extension().unwrap_or(OsStr::new("")),
             false => OsStr::new("folder"),
+        };
+
+        let ext = String::from(ext.to_str().unwrap());
+        let name = String::from(path.file_name().unwrap().to_str().unwrap());
+        let name = match path.is_file() {
+            true if ext.len() <= 0 => name,
+            true => String::from(name.slice(..name.chars().count() - ext.chars().count() - 1)),
+            false => name,
         };
 
         Ok(
             ResourceFileVO {
                 uuid: String::from("id"),
-                name: String::from(path.file_name().unwrap().to_str().unwrap()),
-                ext: String::from(ext.to_str().unwrap()),
+                name: name,
+                ext: ext,
                 path: String::from(main_path),
             }
         )

--- a/src-tauri/src/modules/resource/domain/valueobj/filevo.rs
+++ b/src-tauri/src/modules/resource/domain/valueobj/filevo.rs
@@ -1,4 +1,3 @@
-use std::ffi::OsStr;
 use std::path::Path;
 
 use serde::Serialize;
@@ -11,7 +10,7 @@ pub struct ResourceFileVO {
     pub uuid: String,
     pub name: String,
     pub path: String,
-    pub ext: String,
+    pub ext: Option<String>,
 }
 
 impl ResourceFileVO {
@@ -33,15 +32,16 @@ impl ResourceFileVO {
         }
 
         let ext = match path.is_file() {
-            true => path.extension().unwrap_or(OsStr::new("")),
-            false => OsStr::new("folder"),
+            true => path.extension()
+                .map(|osr| Some(String::from(osr.to_str().unwrap())))
+                .unwrap_or(None),
+            false => Some("folder".to_string()),
         };
 
-        let ext = String::from(ext.to_str().unwrap());
         let name = String::from(path.file_name().unwrap().to_str().unwrap());
         let name = match path.is_file() {
-            true if ext.len() <= 0 => name,
-            true => String::from(name.slice(..name.chars().count() - ext.chars().count() - 1)),
+            true if ext.is_none()=> name,
+            true => String::from(name.slice(..name.chars().count() - ext.as_ref().unwrap().chars().count() - 1)),
             false => name,
         };
 

--- a/src-tauri/src/modules/resource/repository/data_model.rs
+++ b/src-tauri/src/modules/resource/repository/data_model.rs
@@ -6,7 +6,7 @@ pub struct ResourceFileDo {
     pub uuid: String,
     pub name: String,
     pub path: String,
-    pub ext: String,
+    pub ext: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/api/resource/Dto.ts
+++ b/src/api/resource/Dto.ts
@@ -48,6 +48,12 @@ export interface ResourceCreateDto {
     url_path?: string | null,
 }
 
+export interface ResourceRenameFileDto {
+    id: string,
+
+    new_name?: string,
+}
+
 export interface ResourceUpdateDto {
     id: string,
 

--- a/src/api/resource/ResourceAPI.ts
+++ b/src/api/resource/ResourceAPI.ts
@@ -4,6 +4,7 @@ import {
     QueryResoruceDto,
     ResourceCreateDto,
     ResourceDetailDto,
+    ResourceRenameFileDto,
     ResourceResDto,
     ResourceTagOperateDto,
     ResourceUpdateDto,
@@ -38,6 +39,10 @@ export namespace ResourceAPI {
 
     export function update(data: ResourceUpdateDto) {
         return invoke<string>('update_resource', { data });
+    }
+
+    export function renameTheFile(data: ResourceRenameFileDto) {
+        return invoke<string>('rename_resource_file_name', { data });
     }
 
     export function exporeTheFile(filePath: string) {

--- a/src/api/resource/ResourceMutation.ts
+++ b/src/api/resource/ResourceMutation.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { ResourceAPI } from './ResourceAPI';
-import { ResourceCreateDto, ResourceTagOperateDto, ResourceUpdateDto, ResourceUpdateTagDto } from './Dto';
+import { ResourceCreateDto, ResourceRenameFileDto, ResourceTagOperateDto, ResourceUpdateDto, ResourceUpdateTagDto } from './Dto';
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace ResourceMutation {
@@ -18,6 +18,12 @@ export namespace ResourceMutation {
 
     export function useExporeFile() {
         const mutationFn = (filePath: string) => ResourceAPI.exporeTheFile(filePath);
+
+        return useMutation({ mutationFn: mutationFn });
+    }
+
+    export function useRenameFile() {
+        const mutationFn = (data: ResourceRenameFileDto) => ResourceAPI.renameTheFile(data);
 
         return useMutation({ mutationFn: mutationFn });
     }

--- a/src/assets/locales/pages/resource-detail/en-US.json
+++ b/src/assets/locales/pages/resource-detail/en-US.json
@@ -1,0 +1,9 @@
+{
+    "Main": {
+        "name": "name",
+        "description": "description"
+    },
+    "Icons": {
+        "rename": "Rename the file by current name"
+    }
+}

--- a/src/assets/locales/pages/resource-detail/zh-TW.json
+++ b/src/assets/locales/pages/resource-detail/zh-TW.json
@@ -1,0 +1,9 @@
+{
+    "Main": {
+        "name": "名稱",
+        "description": "描述"
+    },
+    "Icons": {
+        "rename": "使用現在的名稱重新命名此檔案"
+    }
+}

--- a/src/modules/i18next/i18next.ts
+++ b/src/modules/i18next/i18next.ts
@@ -8,6 +8,7 @@ import commonEN_US from '@assets/locales/common/en-US.json';
 import pageCommonEN_US from '@assets/locales/pages/common/en-US.json';
 import pageCategorylistEN_US from '@assets/locales/pages/category-list/en-US.json';
 import pageResourcelistEN_US from '@assets/locales/pages/resource-list/en-US.json';
+import pageResourceDetailEN_US from '@assets/locales/pages/resource-detail/en-US.json';
 import pageResourceAddEN_US from '@assets/locales/pages/resource-add/en-US.json';
 import modalTagCreateEN_US from '@assets/locales/modal/create-tag/en-US.json';
 
@@ -15,6 +16,7 @@ import commonZH_TW from '@assets/locales/common/zh-TW.json';
 import pageCommonZH_TW from '@assets/locales/pages/common/zh-TW.json';
 import pageCategorylistZH_TW from '@assets/locales/pages/category-list/zh-TW.json';
 import pageResourcelistZH_TW from '@assets/locales/pages/resource-list/zh-TW.json';
+import pageResourceDetailZH_TW from '@assets/locales/pages/resource-detail/zh-TW.json';
 import pageResourceAddZH_TW from '@assets/locales/pages/resource-add/zh-TW.json';
 import modalTagCreateZH_TW from '@assets/locales/modal/create-tag/zh-TW.json';
 
@@ -39,20 +41,22 @@ export const resources = {
     [SupportLangs.enUS.key]: {
         common: commonEN_US,
         pages:  {
-            Common:       pageCommonEN_US,
-            CategoryList: pageCategorylistEN_US,
-            resourceList: pageResourcelistEN_US,
-            resourceAdd:  pageResourceAddEN_US,
+            Common:         pageCommonEN_US,
+            CategoryList:   pageCategorylistEN_US,
+            resourceList:   pageResourcelistEN_US,
+            resourceDetail: pageResourceDetailEN_US,
+            resourceAdd:    pageResourceAddEN_US,
         },
         modal: { createTag: modalTagCreateEN_US },
     },
     [SupportLangs.zhTW.key]: {
         common: commonZH_TW,
         pages:  {
-            Common:       pageCommonZH_TW,
-            CategoryList: pageCategorylistZH_TW,
-            resourceList: pageResourcelistZH_TW,
-            resourceAdd:  pageResourceAddZH_TW,
+            Common:         pageCommonZH_TW,
+            CategoryList:   pageCategorylistZH_TW,
+            resourceList:   pageResourcelistZH_TW,
+            resourceDetail: pageResourceDetailZH_TW,
+            resourceAdd:    pageResourceAddZH_TW,
         },
         modal: { createTag: modalTagCreateZH_TW },
     },

--- a/src/pages/resource-detail/ResourceDetailPage.tsx
+++ b/src/pages/resource-detail/ResourceDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { convertFileSrc } from '@tauri-apps/api/tauri';
 import {
     Box, Grid, Text, Flex, ScrollArea, Affix, rem, Divider, Group,
@@ -18,6 +19,7 @@ import { ResourceAddSubjectSelect, ResourceTagStack, ResourceDisplay, ResourceAc
 import classes from './ResourceDetailPage.module.scss';
 
 export default function ResourcesDetailPage() {
+    const { t } = useTranslation('pages', { keyPrefix: 'resourceDetail.Main' });
     const { activeCategory } = useActiveCategoryRedux();
     const { resourceId } = useParams<ResourceDetailParam>();
 
@@ -103,7 +105,7 @@ export default function ResourcesDetailPage() {
                     </Group>
                     <ScrollArea.Autosize mx="auto" mah="600px" type="hover" classNames={{ scrollbar: 'mgra' }}>
                         <EditableText
-                            name="name"
+                            name={t('name')}
                             fz="1.5rem"
                             fw="bold"
                             value={name || resourceData.name}
@@ -116,7 +118,7 @@ export default function ResourcesDetailPage() {
                             }}
                         />
                         <EditableText
-                            name="description"
+                            name={t('description')}
                             fz="1rem"
                             opacity="0.5"
                             fw="initial"

--- a/src/pages/resource-detail/components/ResourceActionIcons.tsx
+++ b/src/pages/resource-detail/components/ResourceActionIcons.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import { ActionFileIcon, TooltipActionIcon } from '@components/display';
+import { useTranslation } from 'react-i18next';
 import { LuFileType2 } from 'react-icons/lu';
 
 function Rename({ onClick }: { onClick: () => void }) {
+    const { t } = useTranslation('pages', { keyPrefix: 'resourceDetail.Icons' });
     return (
         <TooltipActionIcon
-            label="Rename the file by current name"
+            label={t('rename')}
             color="gold"
             fz="1.25em"
             pos="absolute"

--- a/src/pages/resource-detail/components/ResourceActionIcons.tsx
+++ b/src/pages/resource-detail/components/ResourceActionIcons.tsx
@@ -1,0 +1,40 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import { ActionFileIcon, TooltipActionIcon } from '@components/display';
+import { LuFileType2 } from 'react-icons/lu';
+
+function Rename({ onClick }: { onClick: () => void }) {
+    return (
+        <TooltipActionIcon
+            label="Rename the file by current name"
+            color="gold"
+            fz="1.25em"
+            pos="absolute"
+            right="10px"
+            top="30px"
+            variant="subtle"
+            style={{ zIndex: 5 }}
+            onClick={onClick}
+        >
+            <LuFileType2 />
+        </TooltipActionIcon>
+    );
+}
+
+function Explore({ filePath }: { filePath: string }) {
+    return (
+        <ActionFileIcon
+            filePath={filePath}
+            pos="absolute"
+            top="0px"
+            right="10px"
+            variant="subtle"
+            p={0}
+            fz="1.75em"
+        />
+    );
+}
+
+export function ResourceActionIcons() {}
+
+ResourceActionIcons.Rename = Rename;
+ResourceActionIcons.Explore = Explore;

--- a/src/pages/resource-detail/components/index.ts
+++ b/src/pages/resource-detail/components/index.ts
@@ -1,3 +1,5 @@
 export * from './ResourceTagStack';
 export * from './ResourceAddSubjectSelect';
 export * from './ResourceTagSelect';
+export * from './ResourceActionIcons';
+export * from './ResourceDisplay';


### PR DESCRIPTION
Changed:

![image](https://github.com/Bill2015/maku-everything/assets/63895869/c10d32b4-d358-4a60-81ad-d50e7bc126bf)

Also, change the resource file extension field type, from `String` to `Option<String>` 
Because some files does not contain the file extension.